### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ export GO111MODULE=on
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./*/*")
 
-.PHONY: all build build-cross clean fmt simplify check extra-clean
+.PHONY: all build build-cross clean fmt simplify check extra-clean install-tools
 
 all: clean fmt check build
 
@@ -67,9 +67,10 @@ check:
 HAS_GOX := $(shell command -v gox 2> /dev/null)
 HAS_GOLANGCI  := $(shell command -v golangci-lint 2> /dev/null)
 
+install-tools:
 ifndef HAS_GOX
-	go get -u $(PKG_GOX)
+	(export GO111MODULE=off; go get -u $(PKG_GOX))
 endif
 ifndef HAS_GOLANGCI
-	go get -u $(PKG_GOLANGCI_LINT)
+	(export GO111MODULE=off; go get -u $(PKG_GOLANGCI_LINT))
 endif

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository is based on [@zeerorg](https://github.com/zeerorg/)'s [zeerorg/k
 
 You have several options there:
 
-- use the install script to grab the latest release: 
+- use the install script to grab the latest release:
   - wget: `wget -q -O - https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash`
   - curl: `curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash`
 - Grab a release from the [release tab](https://github.com/rancher/k3d/releases) and install it yourself.
@@ -29,7 +29,9 @@ or...
 
 1. Clone this repo, e.g. via `go get -u github.com/rancher/k3d`
 2. Inside the repo run
-   - `make` to build for your current system
+   - 'make install-tools' to make sure required go packages are installed
+3. Inside the repo run
+   - `make build` to build for your current system
    - `go install` to install it to your `GOPATH`
    - `make build-cross` to build for all systems
 


### PR DESCRIPTION
This patch set should improve the user experience of first time building.  When running "make build" from a freshly cloned repo, I got the following error:

 Makefile:71: *** recipe commences before first target.  Stop. 

The patch set improve the makefile by introduce the install-tools target.