### PR TITLE
Check length of container array to prevent panic

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -327,8 +327,8 @@ func GetKubeConfig(c *cli.Context) error {
 	server, err := docker.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters,
 	})
-	if err != nil {
-		return fmt.Errorf("Couldn't get server container for cluster %s\n%+v", c.String("name"), err)
+	if err != nil || len(server) != 1 {
+		return fmt.Errorf("Couldn't get server container for cluster: %s\n%+v", c.String("name"), err)
 	}
 
 	// get kubeconfig file from container and read contents


### PR DESCRIPTION
I had a cluster that died after starting due to a bad config. I
quickly went to get the kubeconfig and would get a panic with an
out of bounds error.

An alternate would be to look at all containers and not just running.