### PR TITLE
[BUGFIX] cli: Improve error message for 'k3d get-kubeconfig'

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -327,8 +327,13 @@ func GetKubeConfig(c *cli.Context) error {
 	server, err := docker.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters,
 	})
+
 	if err != nil {
-		return fmt.Errorf("Couldn't get server container for cluster %s\n%+v", c.String("name"), err)
+		return fmt.Errorf("Failed to get server container for cluster %s\n%+v", c.String("name"), err)
+	}
+
+	if len(server) == 0 {
+		return fmt.Errorf("No server container for cluster %s", c.String("name"))
 	}
 
 	// get kubeconfig file from container and read contents


### PR DESCRIPTION
Before this change, command:
 $ k3d create -name test
 $ k3d get-kubeconfig

Produces the following error message:

	panic: runtime error: index out of range

	goroutine 1 [running]:
	github.com/rancher/k3d/cli.GetKubeConfig(0xc00031a160, 0x0, 0x0)
		/Users/azhou/projs/k3d/cli/commands.go:335 +0x105d
	github.com/urfave/cli.HandleAction(0x13e7ca0, 0x148f0b0, 0xc00031a160, 0xc000304000, 0x0)
		/Users/azhou/projs/rcloud/pkg/mod/github.com/urfave/cli@v1.20.0/app.go:490 +0xc8
	github.com/urfave/cli.Command.Run(0x1477cb5, 0xe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1480cd8, 0x23, 0x0, ...)
		/Users/azhou/projs/rcloud/pkg/mod/github.com/urfave/cli@v1.20.0/command.go:210 +0x996
	github.com/urfave/cli.(*App).Run(0xc0000bc1a0, 0xc00000e060, 0x2, 0x2, 0x0, 0x0)
		/Users/azhou/projs/rcloud/pkg/mod/github.com/urfave/cli@v1.20.0/app.go:255 +0x6af
	main.main()
		/Users/azhou/projs/k3d/main.go:185 +0x11e0

This patch improve the error message by avoid the panic. Now the output
becomes:

	019/05/02 12:05:30 No server container for cluster k3s_default