### PR TITLE
Makefile: Avoid setting k3s version at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,13 @@ ifeq ($(GIT_TAG),)
 GIT_TAG   := $(shell git describe --always)
 endif
 
-# get latest k3s version
-K3S_TAG		:= $(shell curl --silent "https://api.github.com/repos/rancher/k3s/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-
 # Go options
 GO        ?= go
 PKG       := $(shell go mod vendor)
 TAGS      :=
 TESTS     := .
 TESTFLAGS :=
-LDFLAGS   := -w -s -X github.com/rancher/k3d/version.Version=${GIT_TAG} -X github.com/rancher/k3d/version.K3sVersion=${K3S_TAG}
+LDFLAGS   := -w -s -X github.com/rancher/k3d/version.Version=${GIT_TAG}
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := k3d


### PR DESCRIPTION
This is a follow on patch for #24.  Before this commit:

$ bin/k3d create
2019/05/04 12:47:41 Created cluster network with ID 2a723e21e851d7ded99ea12de154be6b4ee473c92c8fa17913c335be794e490a
2019/05/04 12:47:41 Creating cluster [k3s_default]
2019/05/04 12:47:41 Creating server using docker.io/rancher/k3s:v0.4.0...

After this commit: 

$bin/k3d create -n test
2019/05/04 12:29:03 Created cluster network with ID bd9b6c07838ca1bd003a40b0a9730ecc4f96311af1691666a6375ed53c42c03c
2019/05/04 12:29:03 Creating cluster [test]
2019/05/04 12:29:03 Creating server using docker.io/rancher/k3s:latest..

Notice the k3s tag value change above.

Commit:
	commit e82e95a23d37d50e0c44ae68aa92bbe5f2f4b877
	Author: Chris Carty <chriscartydev@gmail.com>
	Date:   Fri May 3 22:04:39 2019 -0400

	update default K3sVersion to use latest tag

Made the change to use tag "latest" for k3s images by default.

However, without this commit, the default tag will be set to a tag that
was set at the k3d build time.  It is a bit odd to set run time value at build
time in general.  This commit removes the build time setting.