### PR TITLE
[Feature] Add --publish/--add-port flag for port mappings

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -71,6 +71,11 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
+	publishedPorts, err := createPublishedPorts(c.StringSlice("publish"))
+	if (err != nil) {
+		log.Fatalf("ERROR: failed to parse the publish parameter.\n%+v", err)
+	}
+
 	// create the server
 	log.Printf("Creating cluster [%s]", c.String("name"))
 	dockerID, err := createServer(
@@ -81,6 +86,7 @@ func CreateCluster(c *cli.Context) error {
 		env,
 		c.String("name"),
 		strings.Split(c.String("volume"), ","),
+		publishedPorts,
 	)
 	if err != nil {
 		log.Fatalf("ERROR: failed to create cluster\n%+v", err)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -150,6 +150,7 @@ func CreateCluster(c *cli.Context) error {
 				strings.Split(c.String("volume"), ","),
 				i,
 				c.String("port"),
+				publishedPorts,
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -148,7 +148,7 @@ func CreateCluster(c *cli.Context) error {
 				env,
 				c.String("name"),
 				strings.Split(c.String("volume"), ","),
-				strconv.Itoa(i),
+				i,
 				c.String("port"),
 			)
 			if err != nil {

--- a/cli/container.go
+++ b/cli/container.go
@@ -21,6 +21,81 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
+type PublishedPorts struct {
+	ExposedPorts map[nat.Port]struct{}
+	PortBindings   map[nat.Port][]nat.PortBinding
+}
+
+// The factory function for PublishedPorts
+func createPublishedPorts(specs []string) (*PublishedPorts, error) {
+	if  len(specs) == 0 {
+		var newExposedPorts = make(map[nat.Port]struct{}, 1)
+		var newPortBindings = make(map[nat.Port][]nat.PortBinding, 1)
+		return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
+	}
+
+	newExposedPorts, newPortBindings, err := nat.ParsePortSpecs(specs)
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, err
+}
+
+// Create a new PublishedPort structure, with all host ports are changed by a fixed  'offset'
+func (p PublishedPorts) Offset(offset int) (*PublishedPorts) {
+	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts))
+	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings))
+
+	for k, v := range p.ExposedPorts {
+              newExposedPorts[k] = v
+	}
+
+	for k, v := range p.PortBindings {
+		bindings := make([]nat.PortBinding, len(v))
+		for i, b := range v {
+			port, _ := nat.ParsePort(b.HostPort)
+			bindings[i].HostIP = b.HostIP
+			bindings[i].HostPort = fmt.Sprintf("%d",  port + offset)
+		}
+		newPortBindings[k] = bindings
+	}
+
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}
+}
+
+// Create a new PublishedPort struct with one more port, based on 'portSpec'
+func (p *PublishedPorts) AddPort(portSpec string) (*PublishedPorts, error) {
+	portMappings, err := nat.ParsePortSpec(portSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts) + 1)
+	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings) + 1)
+
+	// Populate the new maps
+	for k, v := range p.ExposedPorts {
+              newExposedPorts[k] = v
+	}
+
+	for k, v := range p.PortBindings {
+              newPortBindings[k] = v
+	}
+
+	// Add new ports
+	for _, portMapping := range portMappings {
+		port := portMapping.Port
+		if _, exists := newExposedPorts[port]; !exists {
+			newExposedPorts[port] = struct{}{}
+		}
+
+		bslice, exists := newPortBindings[port];
+		if !exists {
+			bslice = []nat.PortBinding{}
+		}
+		newPortBindings[port] = append(bslice, portMapping.Binding)
+	}
+
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
+}
+
 func startContainer(verbose bool, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (string, error) {
 	ctx := context.Background()
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -190,14 +190,14 @@ func createServer(verbose bool, image string, port string, args []string, env []
 }
 
 // createWorker creates/starts a k3s agent node that connects to the server
-func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string, postfix string, serverPort string) (string, error) {
+func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string, postfix int, serverPort string) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
 	containerLabels["created"] = time.Now().Format("2006-01-02 15:04:05")
 	containerLabels["cluster"] = name
 
-	containerName := fmt.Sprintf("k3d-%s-worker-%s", name, postfix)
+	containerName := fmt.Sprintf("k3d-%s-worker-%d", name, postfix)
 
 	env = append(env, fmt.Sprintf("K3S_URL=https://k3d-%s-server:%s", name, serverPort))
 

--- a/main.go
+++ b/main.go
@@ -55,6 +55,10 @@ func main() {
 					Name:  "volume, v",
 					Usage: "Mount one or more volumes into every node of the cluster (Docker notation: `source:destination[,source:destination]`)",
 				},
+				cli.StringSliceFlag{
+					Name:  "publish, add-port",
+					Usage: "publish k3s node ports to the host (Docker notation: `ip:public:private/proto`, use multiple options to expose more ports)",
+				},
 				cli.StringFlag{
 					Name:  "version",
 					Value: version.GetK3sVersion(),


### PR DESCRIPTION
Add support for --publish option (--add-port is an alias to this option).

With those patches, we can create a cluster with the following command line:

$) bin/k3d create -n test --publish 8080:8080 --publish 9090:30090/udp --workers 1

 $) docker ps
CONTAINER ID        IMAGE                COMMAND                  CREATED             STATUS              PORTS                                                                     NAMES
8e8fd4582cfa        rancher/k3s:v0.5.0   "/bin/k3s agent"         6 seconds ago       Up 5 seconds        0.0.0.0:8081->8080/tcp, 0.0.0.0:9091->30090/udp                           k3d-test-worker-0
c08480a9efef        rancher/k3s:v0.5.0   "/bin/k3s server --h…"   7 seconds ago       Up 6 seconds        0.0.0.0:6443->6443/tcp, 0.0.0.0:8080->8080/tcp, 0.0.0.0:9090->30090/udp   k3d-test-server


I have tested using this feature to deploy both Kubernetes pods using hostPort and k8s services using node port. 