### PR TITLE
[Feature] Add --publish-offset flag for port mappings

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -175,6 +175,7 @@ func CreateCluster(c *cli.Context) error {
 				i,
 				c.String("port"),
 				publishedPorts,
+				c.Int("publish-offset"),
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/container.go
+++ b/cli/container.go
@@ -38,7 +38,7 @@ func createPublishedPorts(specs []string) (*PublishedPorts, error) {
 	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, err
 }
 
-// Create a new PublishedPort structure, with all host ports are changed by a fixed  'offset'
+// Create a new PublishedPort structure, with all host ports are changed by a fixed 'offset'
 func (p PublishedPorts) Offset(offset int) (*PublishedPorts) {
 	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts))
 	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings))
@@ -191,7 +191,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-		  postfix int, serverPort string, pPorts *PublishedPorts) (string, error) {
+		  postfix int, serverPort string, pPorts *PublishedPorts, publishOffset int) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -202,7 +202,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 
 	env = append(env, fmt.Sprintf("K3S_URL=https://k3d-%s-server:%s", name, serverPort))
 
-	workerPublishedPorts := pPorts.Offset(postfix + 1)
+	workerPublishedPorts := pPorts.Offset(publishOffset * (postfix + 1))
 
 	hostConfig := &container.HostConfig{
 		Tmpfs: map[string]string{

--- a/main.go
+++ b/main.go
@@ -62,7 +62,12 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name:  "publish, add-port",
-					Usage: "publish k3s node ports to the host (Docker notation: `ip:public:private/proto`, use multiple options to expose more ports)",
+					Usage: "Publish k3s node ports to the host (Docker notation: `ip:public:private/proto`, use multiple options to expose more ports)",
+				},
+				cli.IntFlag{
+					Name:  "publish-offset, add-port-offset",
+					Value: 1,
+					Usage: "Host port number increments when publishing ports for the worker nodes",
 				},
 				cli.StringFlag{
 					// TODO: to be deprecated


### PR DESCRIPTION
Currently the --publish option accepts port range as its argument. This
works for a single node cluster. When cluster has worker nodes, k3d
currently hard code the published port increments to 1, which
will cause the cluster creation to fail. Add the option allow user
to set the offset.

With --publish-offset, the following cluster can be created
successfully.

$ bin/k3d create --workers 1 --publish 8000-8001:80-81 --publish-offset 2

ONTAINER ID        IMAGE                COMMAND                  CREATED             STATUS              PORTS                                                                NAMES
751496f11f44        rancher/k3s:v0.5.0   "/bin/k3s agent"         4 seconds ago       Up 3 seconds        0.0.0.0:8002->80/tcp, 0.0.0.0:8003->81/tcp                           k3d-k3s-default-worker-0
a8c03ad554a8        rancher/k3s:v0.5.0   "/bin/k3s server --h…"   5 seconds ago       Up 3 seconds        0.0.0.0:6443->6443/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->81/tcp   k3d-k3s-default-server