### PR TITLE
Delete a cluster if it encounters error when starting

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -113,7 +113,12 @@ func CreateCluster(c *cli.Context) error {
 		publishedPorts,
 	)
 	if err != nil {
-		log.Fatalf("ERROR: failed to create cluster\n%+v", err)
+		log.Printf("ERROR: failed to create cluster\n%+v", err)
+		delErr := DeleteCluster(c)
+		if delErr != nil {
+			return delErr
+		}
+		os.Exit(1)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Delete a cluster if it is not started due to port conflicts or any other unforseen error

Signed-off-by: Rishabh Gupta <r.g.gupta@outlook.com>