### PR TITLE
[Feature] Add --no-remove/--no-rm option

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -111,6 +111,7 @@ func CreateCluster(c *cli.Context) error {
 		c.String("name"),
 		strings.Split(c.String("volume"), ","),
 		publishedPorts,
+		!c.Bool("no-remove"),
 	)
 	if err != nil {
 		log.Printf("ERROR: failed to create cluster\n%+v", err)
@@ -180,6 +181,7 @@ func CreateCluster(c *cli.Context) error {
 				i,
 				c.String("port"),
 				publishedPorts,
+				!c.Bool("no-remove"),
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/container.go
+++ b/cli/container.go
@@ -139,7 +139,7 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 }
 
 func createServer(verbose bool, image string, port string, args []string, env []string,
-                  name string, volumes []string, pPorts *PublishedPorts) (string, error) {
+                  name string, volumes []string, pPorts *PublishedPorts, autorm bool) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
 
 	containerLabels := make(map[string]string)
@@ -158,6 +158,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 	hostConfig := &container.HostConfig{
 		PortBindings: serverPublishedPorts.PortBindings,
+		AutoRemove: autorm,
 		Privileged: true,
 	}
 
@@ -191,7 +192,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-		  postfix int, serverPort string, pPorts *PublishedPorts) (string, error) {
+		  postfix int, serverPort string, pPorts *PublishedPorts, autorm bool) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -210,6 +211,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 			"/var/run": "",
 		},
 		PortBindings: workerPublishedPorts.PortBindings,
+		AutoRemove: autorm,
 		Privileged: true,
 	}
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,10 @@ func main() {
 					Name:  "volume, v",
 					Usage: "Mount one or more volumes into every node of the cluster (Docker notation: `source:destination[,source:destination]`)",
 				},
+				cli.BoolFlag{
+					Name:  "no-remove, no-rm",
+					Usage: "Do not remove containers after deletion",
+				},
 				cli.StringSliceFlag{
 					Name:  "publish, add-port",
 					Usage: "publish k3s node ports to the host (Docker notation: `ip:public:private/proto`, use multiple options to expose more ports)",


### PR DESCRIPTION
When a k3s cluster is delete, the container images are not automatically
removed. Overtime, this can cause the file system used by the docker daemon
to fill up.  This patch sets up the auto remove flag when creating k3s
containers, so they are deleted automatically when done.

In case the container images are useful (mostly for debugging purpose),
this patch adds the --no-remove flag.