### PR TITLE
[Enhancement] Center align list output

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -73,6 +73,7 @@ func printClusters(all bool) {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
 	table.SetHeader([]string{"NAME", "IMAGE", "STATUS", "WORKERS"})
 
 	for _, cluster := range clusters {


### PR DESCRIPTION
Make list output center aligne. It is slightly eaier to read.

Before the commit:

$ bin/k3d list --all

+-------------+------------------------------+---------+---------+
|    NAME     |            IMAGE             | STATUS  | WORKERS |
+-------------+------------------------------+---------+---------+
| k3s-default | docker.io/rancher/k3s:v0.5.0 | running | 2/2     |
+-------------+------------------------------+---------+---------+

After this commit:

$ bin/k3d list --all

+-------------+------------------------------+---------+---------+
|    NAME     |            IMAGE             | STATUS  | WORKERS |
+-------------+------------------------------+---------+---------+
| k3s-default | docker.io/rancher/k3s:v0.5.0 | running |   2/2   |
+-------------+------------------------------+---------+---------+

In this output, only the last cell shows up differently.