### PR TITLE
[Feature] Enhanced port mapping (node-specifiers, optional offset, ...)

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -95,7 +95,7 @@ func CreateCluster(c *cli.Context) error {
 	// k3s server arguments
 	// TODO: --port will soon be --api-port since we want to re-use --port for arbitrary port mappings
 	if c.IsSet("port") {
-		log.Println("WARNING: As of v2.0.0 --port will be used for arbitrary port-mappings. It's original functionality can then be used via --api-port.")
+		log.Println("INFO: As of v2.0.0 --port will be used for arbitrary port mapping. Please use --api-port/-a instead for configuring the Api Port")
 	}
 	k3sServerArgs := []string{"--https-listen-port", c.String("api-port")}
 	if c.IsSet("server-arg") || c.IsSet("x") {

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -90,6 +90,10 @@ func CreateCluster(c *cli.Context) error {
 	}
 
 	// k3s server arguments
+	// TODO: --port will soon be --api-port since we want to re-use --port for arbitrary port mappings
+	if c.IsSet("port") {
+		log.Println("WARNING: --port will soon be used for arbitrary port-mappings. It's original functionality can then be used via --api-port.")
+	}
 	k3sServerArgs := []string{"--https-listen-port", c.String("port")}
 	if c.IsSet("server-arg") || c.IsSet("x") {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -71,8 +71,18 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
+	fmt.Println("==========")
+	pm, err := createPortMap(c.StringSlice("publish"))
+	fmt.Printf("pm: %+v \n err: %+v \n", pm, err)
+	for _, x := range *pm {
+		fmt.Printf("x: %+v\n -> Ports: %+v\n", x, x.Ports)
+	}
+	fmt.Println("==========")
 	publishedPorts, err := createPublishedPorts(c.StringSlice("publish"))
-	if (err != nil) {
+	fmt.Printf("pm: %+v \n err: %+v \n", publishedPorts, err)
+	fmt.Println("==========")
+
+	if err != nil {
 		log.Fatalf("ERROR: failed to parse the publish parameter.\n%+v", err)
 	}
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -23,7 +23,10 @@ import (
 	"github.com/urfave/cli"
 )
 
-const defaultRegistry = "docker.io"
+const (
+	defaultRegistry    = "docker.io"
+	defaultServerCount = 1
+)
 
 // CheckTools checks if the docker API server is responding
 func CheckTools(c *cli.Context) error {
@@ -100,7 +103,7 @@ func CreateCluster(c *cli.Context) error {
 	}
 
 	// new port map
-	portmap, err := mapNodesToPortSpecs(c.StringSlice("publish"))
+	portmap, err := mapNodesToPortSpecs(c.StringSlice("publish"), GetAllContainerNames(c.String("name"), defaultServerCount, c.Int("workers")))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -71,19 +71,10 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
-	fmt.Println("==========")
-	pm, err := createPortMap(c.StringSlice("publish"))
-	fmt.Printf("pm: %+v \n err: %+v \n", pm, err)
-	for _, x := range *pm {
-		fmt.Printf("x: %+v\n -> Ports: %+v\n", x, x.Ports)
-	}
-	fmt.Println("==========")
-	publishedPorts, err := createPublishedPorts(c.StringSlice("publish"))
-	fmt.Printf("pm: %+v \n err: %+v \n", publishedPorts, err)
-	fmt.Println("==========")
-
+	// new port map
+	portmap, err := mapNodesToPortSpecs(c.StringSlice("publish"))
 	if err != nil {
-		log.Fatalf("ERROR: failed to parse the publish parameter.\n%+v", err)
+		log.Fatal(err)
 	}
 
 	// create the server
@@ -96,7 +87,7 @@ func CreateCluster(c *cli.Context) error {
 		env,
 		c.String("name"),
 		strings.Split(c.String("volume"), ","),
-		publishedPorts,
+		portmap,
 	)
 	if err != nil {
 		log.Fatalf("ERROR: failed to create cluster\n%+v", err)
@@ -160,12 +151,12 @@ func CreateCluster(c *cli.Context) error {
 				strings.Split(c.String("volume"), ","),
 				i,
 				c.String("port"),
-				publishedPorts,
+				portmap,
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)
 			}
-			fmt.Printf("Created worker with ID %s\n", workerID)
+			log.Printf("Created worker with ID %s\n", workerID)
 		}
 	}
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -92,9 +92,9 @@ func CreateCluster(c *cli.Context) error {
 	// k3s server arguments
 	// TODO: --port will soon be --api-port since we want to re-use --port for arbitrary port mappings
 	if c.IsSet("port") {
-		log.Println("WARNING: --port will soon be used for arbitrary port-mappings. It's original functionality can then be used via --api-port.")
+		log.Println("WARNING: As of v2.0.0 --port will be used for arbitrary port-mappings. It's original functionality can then be used via --api-port.")
 	}
-	k3sServerArgs := []string{"--https-listen-port", c.String("port")}
+	k3sServerArgs := []string{"--https-listen-port", c.String("api-port")}
 	if c.IsSet("server-arg") || c.IsSet("x") {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
@@ -110,7 +110,7 @@ func CreateCluster(c *cli.Context) error {
 	dockerID, err := createServer(
 		c.GlobalBool("verbose"),
 		image,
-		c.String("port"),
+		c.String("api-port"),
 		k3sServerArgs,
 		env,
 		c.String("name"),
@@ -183,8 +183,9 @@ func CreateCluster(c *cli.Context) error {
 				c.String("name"),
 				strings.Split(c.String("volume"), ","),
 				i,
-				c.String("port"),
+				c.String("api-port"),
 				portmap,
+				c.Int("port-auto-offset"),
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,6 +16,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
+const (
+	defaultContainerNamePrefix = "k3d"
+)
+
 type cluster struct {
 	name        string
 	image       string
@@ -23,6 +27,26 @@ type cluster struct {
 	serverPorts []string
 	server      types.Container
 	workers     []types.Container
+}
+
+// GetContainerName generates the container names
+func GetContainerName(role, clusterName string, postfix int) string {
+	if postfix >= 0 {
+		return fmt.Sprintf("%s-%s-%s-%d", defaultContainerNamePrefix, clusterName, role, postfix)
+	}
+	return fmt.Sprintf("%s-%s-%s", defaultContainerNamePrefix, clusterName, role)
+}
+
+// GetAllContainerNames returns a list of all containernames that will be created
+func GetAllContainerNames(clusterName string, serverCount, workerCount int) []string {
+	names := []string{}
+	for postfix := 0; postfix < serverCount; postfix++ {
+		names = append(names, GetContainerName("server", clusterName, postfix))
+	}
+	for postfix := 0; postfix < workerCount; postfix++ {
+		names = append(names, GetContainerName("worker", clusterName, postfix))
+	}
+	return names
 }
 
 // createDirIfNotExists checks for the existence of a directory and creates it along with all required parents if not.

--- a/cli/container.go
+++ b/cli/container.go
@@ -62,7 +62,7 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 	return resp.ID, nil
 }
 
-func createServer(verbose bool, image string, port string, args []string, env []string,
+func createServer(verbose bool, image string, apiPort string, args []string, env []string,
 	name string, volumes []string, nodeToPortSpecMap map[string][]string) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
 
@@ -81,7 +81,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 		return "", err
 	}
 
-	apiPortSpec := fmt.Sprintf("0.0.0.0:%s:%s/tcp", port, port)
+	apiPortSpec := fmt.Sprintf("0.0.0.0:%s:%s/tcp", apiPort, apiPort)
 
 	serverPorts = append(serverPorts, apiPortSpec)
 
@@ -125,7 +125,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-	postfix int, serverPort string, nodeToPortSpecMap map[string][]string) (string, error) {
+	postfix int, serverPort string, nodeToPortSpecMap map[string][]string, portAutoOffset int) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -139,7 +139,6 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	// ports to be assigned to the server belong to roles
 	// all, server or <server-container-name>
 	workerPorts, err := MergePortSpecs(nodeToPortSpecMap, "worker", containerName)
-	fmt.Printf("%s -> ports: %+v\n", containerName, workerPorts)
 	if err != nil {
 		return "", err
 	}
@@ -147,7 +146,11 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	if err != nil {
 		return "", err
 	}
-	workerPublishedPorts = workerPublishedPorts.Offset(postfix + 1)
+	if portAutoOffset > 0 {
+		// TODO: add some checks before to print a meaningful log message saying that we cannot map multiple container ports
+		// to the same host port without a offset
+		workerPublishedPorts = workerPublishedPorts.Offset(postfix + portAutoOffset)
+	}
 
 	hostConfig := &container.HostConfig{
 		Tmpfs: map[string]string{

--- a/cli/container.go
+++ b/cli/container.go
@@ -63,7 +63,7 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 }
 
 func createServer(verbose bool, image string, port string, args []string, env []string,
-	name string, volumes []string, pPorts *PublishedPorts) (string, error) {
+	name string, volumes []string, nodeToPortSpecMap map[string][]string) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
 
 	containerLabels := make(map[string]string)
@@ -74,10 +74,20 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 	containerName := fmt.Sprintf("k3d-%s-server", name)
 
-	apiPortSpec := fmt.Sprintf("0.0.0.0:%s:%s/tcp", port, port)
-	serverPublishedPorts, err := pPorts.AddPort(apiPortSpec)
+	// ports to be assigned to the server belong to roles
+	// all, server or <server-container-name>
+	serverPorts, err := MergePortSpecs(nodeToPortSpecMap, "server", containerName)
 	if err != nil {
-		log.Fatalf("Error: failed to parse API port spec %s \n%+v", apiPortSpec, err)
+		return "", err
+	}
+
+	apiPortSpec := fmt.Sprintf("0.0.0.0:%s:%s/tcp", port, port)
+
+	serverPorts = append(serverPorts, apiPortSpec)
+
+	serverPublishedPorts, err := CreatePublishedPorts(serverPorts)
+	if err != nil {
+		log.Fatalf("Error: failed to parse port specs %+v \n%+v", serverPorts, err)
 	}
 
 	hostConfig := &container.HostConfig{
@@ -115,7 +125,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-	postfix int, serverPort string, pPorts *PublishedPorts) (string, error) {
+	postfix int, serverPort string, nodeToPortSpecMap map[string][]string) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -126,7 +136,17 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 
 	env = append(env, fmt.Sprintf("K3S_URL=https://k3d-%s-server:%s", name, serverPort))
 
-	workerPublishedPorts := pPorts.Offset(postfix + 1)
+	// ports to be assigned to the server belong to roles
+	// all, server or <server-container-name>
+	workerPorts, err := MergePortSpecs(nodeToPortSpecMap, "worker", containerName)
+	if err != nil {
+		return "", err
+	}
+	workerPublishedPorts, err := CreatePublishedPorts(workerPorts)
+	if err != nil {
+		return "", err
+	}
+	workerPublishedPorts = workerPublishedPorts.Offset(postfix + 1)
 
 	hostConfig := &container.HostConfig{
 		Tmpfs: map[string]string{

--- a/cli/container.go
+++ b/cli/container.go
@@ -139,6 +139,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	// ports to be assigned to the server belong to roles
 	// all, server or <server-container-name>
 	workerPorts, err := MergePortSpecs(nodeToPortSpecMap, "worker", containerName)
+	fmt.Printf("%s -> ports: %+v\n", containerName, workerPorts)
 	if err != nil {
 		return "", err
 	}

--- a/cli/container.go
+++ b/cli/container.go
@@ -72,7 +72,7 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 	containerLabels["created"] = time.Now().Format("2006-01-02 15:04:05")
 	containerLabels["cluster"] = name
 
-	containerName := fmt.Sprintf("k3d-%s-server", name)
+	containerName := GetContainerName("server", name, -1)
 
 	// ports to be assigned to the server belong to roles
 	// all, server or <server-container-name>
@@ -132,7 +132,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	containerLabels["created"] = time.Now().Format("2006-01-02 15:04:05")
 	containerLabels["cluster"] = name
 
-	containerName := fmt.Sprintf("k3d-%s-worker-%d", name, postfix)
+	containerName := GetContainerName("worker", name, postfix)
 
 	env = append(env, fmt.Sprintf("K3S_URL=https://k3d-%s-server:%s", name, serverPort))
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -18,83 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
 )
-
-type PublishedPorts struct {
-	ExposedPorts map[nat.Port]struct{}
-	PortBindings   map[nat.Port][]nat.PortBinding
-}
-
-// The factory function for PublishedPorts
-func createPublishedPorts(specs []string) (*PublishedPorts, error) {
-	if  len(specs) == 0 {
-		var newExposedPorts = make(map[nat.Port]struct{}, 1)
-		var newPortBindings = make(map[nat.Port][]nat.PortBinding, 1)
-		return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
-	}
-
-	newExposedPorts, newPortBindings, err := nat.ParsePortSpecs(specs)
-	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, err
-}
-
-// Create a new PublishedPort structure, with all host ports are changed by a fixed  'offset'
-func (p PublishedPorts) Offset(offset int) (*PublishedPorts) {
-	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts))
-	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings))
-
-	for k, v := range p.ExposedPorts {
-              newExposedPorts[k] = v
-	}
-
-	for k, v := range p.PortBindings {
-		bindings := make([]nat.PortBinding, len(v))
-		for i, b := range v {
-			port, _ := nat.ParsePort(b.HostPort)
-			bindings[i].HostIP = b.HostIP
-			bindings[i].HostPort = fmt.Sprintf("%d",  port + offset)
-		}
-		newPortBindings[k] = bindings
-	}
-
-	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}
-}
-
-// Create a new PublishedPort struct with one more port, based on 'portSpec'
-func (p *PublishedPorts) AddPort(portSpec string) (*PublishedPorts, error) {
-	portMappings, err := nat.ParsePortSpec(portSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts) + 1)
-	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings) + 1)
-
-	// Populate the new maps
-	for k, v := range p.ExposedPorts {
-              newExposedPorts[k] = v
-	}
-
-	for k, v := range p.PortBindings {
-              newPortBindings[k] = v
-	}
-
-	// Add new ports
-	for _, portMapping := range portMappings {
-		port := portMapping.Port
-		if _, exists := newExposedPorts[port]; !exists {
-			newExposedPorts[port] = struct{}{}
-		}
-
-		bslice, exists := newPortBindings[port];
-		if !exists {
-			bslice = []nat.PortBinding{}
-		}
-		newPortBindings[port] = append(bslice, portMapping.Binding)
-	}
-
-	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
-}
 
 func startContainer(verbose bool, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (string, error) {
 	ctx := context.Background()
@@ -139,7 +63,7 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 }
 
 func createServer(verbose bool, image string, port string, args []string, env []string,
-                  name string, volumes []string, pPorts *PublishedPorts) (string, error) {
+	name string, volumes []string, pPorts *PublishedPorts) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
 
 	containerLabels := make(map[string]string)
@@ -152,13 +76,13 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 	apiPortSpec := fmt.Sprintf("0.0.0.0:%s:%s/tcp", port, port)
 	serverPublishedPorts, err := pPorts.AddPort(apiPortSpec)
-	if (err != nil) {
+	if err != nil {
 		log.Fatalf("Error: failed to parse API port spec %s \n%+v", apiPortSpec, err)
 	}
 
 	hostConfig := &container.HostConfig{
 		PortBindings: serverPublishedPorts.PortBindings,
-		Privileged: true,
+		Privileged:   true,
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
@@ -174,12 +98,12 @@ func createServer(verbose bool, image string, port string, args []string, env []
 	}
 
 	config := &container.Config{
-		Hostname: containerName,
-		Image:    image,
-		Cmd:      append([]string{"server"}, args...),
+		Hostname:     containerName,
+		Image:        image,
+		Cmd:          append([]string{"server"}, args...),
 		ExposedPorts: serverPublishedPorts.ExposedPorts,
-		Env:    env,
-		Labels: containerLabels,
+		Env:          env,
+		Labels:       containerLabels,
 	}
 	id, err := startContainer(verbose, config, hostConfig, networkingConfig, containerName)
 	if err != nil {
@@ -191,7 +115,7 @@ func createServer(verbose bool, image string, port string, args []string, env []
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-		  postfix int, serverPort string, pPorts *PublishedPorts) (string, error) {
+	postfix int, serverPort string, pPorts *PublishedPorts) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -210,7 +134,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 			"/var/run": "",
 		},
 		PortBindings: workerPublishedPorts.PortBindings,
-		Privileged: true,
+		Privileged:   true,
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
@@ -226,10 +150,10 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	}
 
 	config := &container.Config{
-		Hostname: containerName,
-		Image:    image,
-		Env:      env,
-		Labels:   containerLabels,
+		Hostname:     containerName,
+		Image:        image,
+		Env:          env,
+		Labels:       containerLabels,
 		ExposedPorts: workerPublishedPorts.ExposedPorts,
 	}
 

--- a/cli/port.go
+++ b/cli/port.go
@@ -15,7 +15,7 @@ type PublishedPorts struct {
 }
 
 // defaultNodes describes the type of nodes on which a port should be exposed by default
-const defaultNodes = "all"
+const defaultNodes = "server"
 
 // mapping a node role to groups that should be applied to it
 var nodeRuleGroupsMap = map[string][]string{

--- a/cli/port.go
+++ b/cli/port.go
@@ -59,11 +59,11 @@ func CreatePublishedPorts(specs []string) (*PublishedPorts, error) {
 
 // validatePortSpecs matches the provided port specs against a set of rules to enable early exit if something is wrong
 func validatePortSpecs(specs []string) error {
-	// regex matching (no sophisticated IP/Hostname matching at the moment)
-	regex := regexp.MustCompile(`^(((?P<host>[\w\.]+)?:)?((?P<hostPort>[0-9]{0,6}):)?(?P<containerPort>[0-9]{1,6}))((/(?P<protocol>udp|tcp))?(?P<nodes>(@(?P<node>[\w-]+))*))$`)
+	// regex matching (no sophisticated IP matching at the moment)
+	regex := regexp.MustCompile(`^(((?P<ip>[\d\.]+)?:)?((?P<hostPort>[0-9]{0,6}):)?(?P<containerPort>[0-9]{1,6}))((/(?P<protocol>udp|tcp))?(?P<nodes>(@(?P<node>[\w-]+))+))$`)
 	for _, spec := range specs {
 		if !regex.MatchString(spec) {
-			return fmt.Errorf("[ERROR] Provided port spec [%s] didn't match format specification", spec)
+			return fmt.Errorf("[ERROR] Provided port spec [%s] didn't match format specification (`[ip:][host-port:]container-port[/protocol]@node-specifier`)", spec)
 		}
 	}
 	return nil

--- a/cli/port.go
+++ b/cli/port.go
@@ -39,6 +39,10 @@ func mapNodesToPortSpecs(specs []string, createdNodes []string) (map[string][]st
 	for _, spec := range specs {
 		nodes, portSpec := extractNodes(spec)
 
+		if len(nodes) == 0 {
+			nodes = append(nodes, defaultNodes)
+		}
+
 		for _, node := range nodes {
 			// check if node-specifier is valid (either a role or a name) and append to list if matches
 			nodeFound := false

--- a/cli/port.go
+++ b/cli/port.go
@@ -1,0 +1,153 @@
+package run
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/docker/go-connections/nat"
+)
+
+// PublishedPorts is a struct used for exposing container ports on the host system
+type PublishedPorts struct {
+	ExposedPorts map[nat.Port]struct{}
+	PortBindings map[nat.Port][]nat.PortBinding
+}
+
+// Portmap maps node roles/names to a set of PublishedPorts
+type Portmap struct {
+	Node  string
+	Ports *PublishedPorts
+}
+
+// defaultNodes describes the type of nodes on which a port should be exposed by default
+const defaultNodes = "all"
+
+// createPortMap creates a list of portmaps that map nodes (roles or names) to a list of published ports
+func createPortMap(specs []string) (*[]Portmap, error) {
+
+	if err := validatePortSpecs(specs); err != nil {
+		return nil, err
+	}
+
+	nodeToPortSpecMap := make(map[string][]string)
+
+	for _, spec := range specs {
+		nodes, portSpec := extractNodes(spec)
+
+		for _, node := range nodes {
+			nodeToPortSpecMap[node] = append(nodeToPortSpecMap[node], portSpec)
+		}
+	}
+
+	portmaps := []Portmap{}
+	for node, portSpecs := range nodeToPortSpecMap {
+		ports, err := createPublishedPorts(portSpecs)
+		if err != nil {
+			return nil, err
+		}
+		newPortMap := Portmap{
+			Node:  node,
+			Ports: ports,
+		}
+		portmaps = append(portmaps, newPortMap)
+	}
+	return &portmaps, nil
+}
+
+// The factory function for PublishedPorts
+func createPublishedPorts(specs []string) (*PublishedPorts, error) {
+	if len(specs) == 0 {
+		var newExposedPorts = make(map[nat.Port]struct{}, 1)
+		var newPortBindings = make(map[nat.Port][]nat.PortBinding, 1)
+		return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
+	}
+
+	newExposedPorts, newPortBindings, err := nat.ParsePortSpecs(specs)
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, err
+}
+
+// validatePortSpecs matches the provided port specs against a set of rules to enable early exit if something is wrong
+func validatePortSpecs(specs []string) error {
+	// regex matching (no sophisticated IP/Hostname matching at the moment)
+	regex := regexp.MustCompile(`^(((?P<host>[\w\.]+)?:)?((?P<hostPort>[0-9]{0,6}):)?(?P<containerPort>[0-9]{1,6}))((/(?P<protocol>udp|tcp))?(?P<nodes>(@(?P<node>[\w-]+))*))$`)
+	for _, spec := range specs {
+		if !regex.MatchString(spec) {
+			return fmt.Errorf("[ERROR] Provided port spec [%s] didn't match format specification", spec)
+		}
+	}
+	return nil
+}
+
+// extractNodes separates the node specification from the actual port specs
+func extractNodes(spec string) ([]string, string) {
+	// extract nodes
+	nodes := []string{}
+	atSplit := strings.Split(spec, "@")
+	portSpec := atSplit[0]
+	if len(atSplit) > 1 {
+		nodes = atSplit[1:]
+	}
+	if len(nodes) == 0 {
+		nodes = append(nodes, defaultNodes)
+	}
+	return nodes, portSpec
+}
+
+// Offset creates a new PublishedPort structure, with all host ports are changed by a fixed  'offset'
+func (p PublishedPorts) Offset(offset int) *PublishedPorts {
+	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts))
+	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings))
+
+	for k, v := range p.ExposedPorts {
+		newExposedPorts[k] = v
+	}
+
+	for k, v := range p.PortBindings {
+		bindings := make([]nat.PortBinding, len(v))
+		for i, b := range v {
+			port, _ := nat.ParsePort(b.HostPort)
+			bindings[i].HostIP = b.HostIP
+			bindings[i].HostPort = fmt.Sprintf("%d", port+offset)
+		}
+		newPortBindings[k] = bindings
+	}
+
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}
+}
+
+// AddPort creates a new PublishedPort struct with one more port, based on 'portSpec'
+func (p *PublishedPorts) AddPort(portSpec string) (*PublishedPorts, error) {
+	portMappings, err := nat.ParsePortSpec(portSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts)+1)
+	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings)+1)
+
+	// Populate the new maps
+	for k, v := range p.ExposedPorts {
+		newExposedPorts[k] = v
+	}
+
+	for k, v := range p.PortBindings {
+		newPortBindings[k] = v
+	}
+
+	// Add new ports
+	for _, portMapping := range portMappings {
+		port := portMapping.Port
+		if _, exists := newExposedPorts[port]; !exists {
+			newExposedPorts[port] = struct{}{}
+		}
+
+		bslice, exists := newPortBindings[port]
+		if !exists {
+			bslice = []nat.PortBinding{}
+		}
+		newPortBindings[port] = append(bslice, portMapping.Binding)
+	}
+
+	return &PublishedPorts{ExposedPorts: newExposedPorts, PortBindings: newPortBindings}, nil
+}

--- a/cli/port.go
+++ b/cli/port.go
@@ -40,8 +40,6 @@ func mapNodesToPortSpecs(specs []string) (map[string][]string, error) {
 		}
 	}
 
-	fmt.Printf("nodeToPortSpecMap: %+v\n", nodeToPortSpecMap)
-
 	return nodeToPortSpecMap, nil
 }
 

--- a/cli/port.go
+++ b/cli/port.go
@@ -112,7 +112,7 @@ func (p PublishedPorts) Offset(offset int) *PublishedPorts {
 		for i, b := range v {
 			port, _ := nat.ParsePort(b.HostPort)
 			bindings[i].HostIP = b.HostIP
-			bindings[i].HostPort = fmt.Sprintf("%d", port+offset)
+			bindings[i].HostPort = fmt.Sprintf("%d", port*offset)
 		}
 		newPortBindings[k] = bindings
 	}

--- a/cli/util.go
+++ b/cli/util.go
@@ -47,11 +47,15 @@ const clusterNameMaxSize int = 35
 // within the 64 characters limit.
 func CheckClusterName(name string) error {
 	if len(name) > clusterNameMaxSize {
-		return fmt.Errorf("[ERROR] Cluster name is too long")
+		return fmt.Errorf("[ERROR] Cluster name is too long (%d > %d)", len(name), clusterNameMaxSize)
 	}
+	return fmt.Errorf("[ERROR] Invalid cluster name\n%+v", ValidateHostname(name))
+}
 
+// ValidateHostname ensures that a cluster name is also a valid host name according to RFC 1123.
+func ValidateHostname(name string) error {
 	if name[0] == '-' || name[len(name)-1] == '-' {
-		return fmt.Errorf("[ERROR] Cluster name can not start or end with - (dash)")
+		return fmt.Errorf("[ERROR] Hostname [%s] must not start or end with - (dash)", name)
 	}
 
 	for _, c := range name {
@@ -62,7 +66,7 @@ func CheckClusterName(name string) error {
 		case c == '-':
 			break
 		default:
-			return fmt.Errorf("[ERROR] Cluster name contains characters other than 'Aa-Zz', '0-9' or '-'")
+			return fmt.Errorf("[ERROR] Hostname [%s] contains characters other than 'Aa-Zz', '0-9' or '-'", name)
 
 		}
 	}

--- a/cli/util.go
+++ b/cli/util.go
@@ -49,7 +49,10 @@ func CheckClusterName(name string) error {
 	if len(name) > clusterNameMaxSize {
 		return fmt.Errorf("[ERROR] Cluster name is too long (%d > %d)", len(name), clusterNameMaxSize)
 	}
-	return fmt.Errorf("[ERROR] Invalid cluster name\n%+v", ValidateHostname(name))
+	if err := ValidateHostname(name); err != nil {
+		return fmt.Errorf("[ERROR] Invalid cluster name\n%+v", ValidateHostname(name))
+	}
+	return nil
 }
 
 // ValidateHostname ensures that a cluster name is also a valid host name according to RFC 1123.

--- a/cli/util.go
+++ b/cli/util.go
@@ -46,17 +46,22 @@ const clusterNameMaxSize int = 35
 // so that we can construct the host names based on the cluster name, and still stay
 // within the 64 characters limit.
 func CheckClusterName(name string) error {
-	if len(name) > clusterNameMaxSize {
-		return fmt.Errorf("[ERROR] Cluster name is too long (%d > %d)", len(name), clusterNameMaxSize)
-	}
 	if err := ValidateHostname(name); err != nil {
 		return fmt.Errorf("[ERROR] Invalid cluster name\n%+v", ValidateHostname(name))
+	}
+	if len(name) > clusterNameMaxSize {
+		return fmt.Errorf("[ERROR] Cluster name is too long (%d > %d)", len(name), clusterNameMaxSize)
 	}
 	return nil
 }
 
 // ValidateHostname ensures that a cluster name is also a valid host name according to RFC 1123.
 func ValidateHostname(name string) error {
+
+	if len(name) == 0 {
+		return fmt.Errorf("[ERROR] no name provided")
+	}
+
 	if name[0] == '-' || name[len(name)-1] == '-' {
 		return fmt.Errorf("[ERROR] Hostname [%s] must not start or end with - (dash)", name)
 	}

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 				cli.IntFlag{
 					Name:  "port-auto-offset",
 					Value: 0,
-					Usage: "Automatically add an offset (+ worker number) to the chosen host port when using `--publish` to map the same container-port from multiple k3d workers to the host",
+					Usage: "Automatically add an offset (* worker number) to the chosen host port when using `--publish` to map the same container-port from multiple k3d workers to the host",
 				},
 				cli.StringFlag{
 					// TODO: to be deprecated

--- a/main.go
+++ b/main.go
@@ -62,7 +62,12 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name:  "publish, add-port",
-					Usage: "publish k3s node ports to the host (Format: `[ip:][host-port:]container-port[/protocol]@node-specifier`, use multiple options to expose more ports)",
+					Usage: "Publish k3s node ports to the host (Format: `[ip:][host-port:]container-port[/protocol]@node-specifier`, use multiple options to expose more ports)",
+				},
+				cli.IntFlag{
+					Name:  "port-auto-offset",
+					Value: 0,
+					Usage: "Automatically add an offset (+ worker number) to the chosen host port when using `--publish` to map the same container-port from multiple k3d workers to the host",
 				},
 				cli.StringFlag{
 					// TODO: to be deprecated
@@ -70,9 +75,10 @@ func main() {
 					Usage: "Choose the k3s image version",
 				},
 				cli.IntFlag{
-					Name:  "port, p",
+					// TODO: only --api-port, -a soon since we want to use --port, -p for the --publish/--add-port functionality
+					Name:  "api-port, a, port, p",
 					Value: 6443,
-					Usage: "Map the Kubernetes ApiServer port to a local port",
+					Usage: "Map the Kubernetes ApiServer port to a local port (Note: --port/-p will have different functionality as of v2.0.0)",
 				},
 				cli.IntFlag{
 					Name:  "timeout, t",

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 					// TODO: only --api-port, -a soon since we want to use --port, -p for the --publish/--add-port functionality
 					Name:  "api-port, a, port, p",
 					Value: 6443,
-					Usage: "Map the Kubernetes ApiServer port to a local port (Note: --port/-p will have different functionality as of v2.0.0)",
+					Usage: "Map the Kubernetes ApiServer port to a local port (Note: --port/-p will be used for arbitrary port mapping as of v2.0.0, use --api-port/-a instead for setting the api port)",
 				},
 				cli.IntFlag{
 					Name:  "timeout, t",

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name:  "publish, add-port",
-					Usage: "publish k3s node ports to the host (Docker notation: `ip:public:private/proto`, use multiple options to expose more ports)",
+					Usage: "publish k3s node ports to the host (Format: `[ip:][host-port:]container-port[/protocol]@node-specifier`, use multiple options to expose more ports)",
 				},
 				cli.StringFlag{
 					// TODO: to be deprecated


### PR DESCRIPTION
This PR changes quite a lot of things and builds on top of PR #32 .
It's another attempt to improve the situation regarding issue #11.

**Changes:**

* `--publish`/`--add-port` syntax is now `[ip:][host-port:]container-port[/protocol]@node-specifier`, where container-port and node-specifier are mandatory and node-specifier can be one or multiple
  - node-specifier can be either one of `all`, `server`, `worker` or the name of a node that will be created (easier naming will follow, since e.g. `k3d-some-test-name-worker-0` is not convenient to use)
  - since the node-specifier is mandatory, we won't automatically map ports to multiple nodes
* `--api-port`/`-a` is now the default to set the K8s ApiPort mapping, since we want to re-use `--port`/`-p` for the functionality of `--publish`/`--add-port`
* You can toggle/set a automatic port offset for mapping the same container-port from multiple worker nodes to predictable host-ports using the new `--port-auto-offset X` flag with X > 0.
  - if a multi-node portmapping is specified (e.g. `--publish 1234:4321@workers`) without the auto offset flag set, the docker API will return an error due to colliding ports

FYI @andyz-dev , @mash-graz, @goffinf