### PR TITLE
[Enhancement] Allow the volume argument to be specified multiple times

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -117,7 +117,7 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs,
 		env,
 		c.String("name"),
-		strings.Split(c.String("volume"), ","),
+		c.StringSlice("volume"),
 		portmap,
 	)
 	if err != nil {
@@ -184,7 +184,7 @@ func CreateCluster(c *cli.Context) error {
 				k3sWorkerArgs,
 				env,
 				c.String("name"),
-				strings.Split(c.String("volume"), ","),
+				c.StringSlice("volume"),
 				i,
 				c.String("api-port"),
 				portmap,

--- a/main.go
+++ b/main.go
@@ -56,9 +56,9 @@ func main() {
 					Value: defaultK3sClusterName,
 					Usage: "Set a name for the cluster",
 				},
-				cli.StringFlag{
+				cli.StringSliceFlag{
 					Name:  "volume, v",
-					Usage: "Mount one or more volumes into every node of the cluster (Docker notation: `source:destination[,source:destination]`)",
+					Usage: "Mount one or more volumes into every node of the cluster (Docker notation: `source:destination`)",
 				},
 				cli.StringSliceFlag{
 					Name:  "publish, add-port",


### PR DESCRIPTION
Most k3d arguments are using in "stringSlice" style, allowing the
argument to supplied multiple times. Currently "volume" is an exception
to this style, require multiple arguments to be supplied in a single
argument, separated by comma.

This commit improve the k3d usability by improve the consistency of its
argument style.