### PR TITLE
[Feature] support mapped btrfs devices on Linux

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -28,8 +28,16 @@ const (
 	defaultServerCount = 1
 )
 
-// Bind mount /dev/mapper for linux users who have lvm/luks/etc in use.
-var defaultBindMounts = []string{"/dev/mapper:/dev/mapper"}
+var defaultBindMounts = make([]string, 0)
+
+func init() {
+	// populate default bind mounts
+	// IsNotExist check instead of nil in case we don't have perms, but docker will
+	if _, err := os.Stat("/dev/mapper"); !os.IsNotExist(err) {
+		// Bind mount /dev/mapper for linux users who have lvm/luks/etc in use.
+		defaultBindMounts = append(defaultBindMounts, "/dev/mapper:/dev/mapper")
+	}
+}
 
 // CheckTools checks if the docker API server is responding
 func CheckTools(c *cli.Context) error {

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -28,16 +28,7 @@ const (
 	defaultServerCount = 1
 )
 
-var defaultBindMounts = make([]string, 0)
-
-func init() {
-	// populate default bind mounts
-	// IsNotExist check instead of nil in case we don't have perms, but docker will
-	if _, err := os.Stat("/dev/mapper"); !os.IsNotExist(err) {
-		// Bind mount /dev/mapper for linux users who have lvm/luks/etc in use.
-		defaultBindMounts = append(defaultBindMounts, "/dev/mapper:/dev/mapper")
-	}
-}
+var defaultBindMounts = []string{"/dev/mapper:/dev/mapper"}
 
 // CheckTools checks if the docker API server is responding
 func CheckTools(c *cli.Context) error {
@@ -135,7 +126,7 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs,
 		env,
 		c.String("name"),
-		c.StringSlice("volume"),
+		checkDefaultBindMounts(c.StringSlice("volume"), defaultBindMounts),
 		portmap,
 	)
 	if err != nil {
@@ -202,7 +193,7 @@ func CreateCluster(c *cli.Context) error {
 				k3sWorkerArgs,
 				env,
 				c.String("name"),
-				c.StringSlice("volume"),
+				checkDefaultBindMounts(c.StringSlice("volume"), defaultBindMounts),
 				i,
 				c.String("api-port"),
 				portmap,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -28,6 +28,9 @@ const (
 	defaultServerCount = 1
 )
 
+// Bind mount /dev/mapper for linux users who have lvm/luks/etc in use.
+var defaultBindMounts = []string{"/dev/mapper:/dev/mapper"}
+
 // CheckTools checks if the docker API server is responding
 func CheckTools(c *cli.Context) error {
 	log.Print("Checking docker...")

--- a/cli/container.go
+++ b/cli/container.go
@@ -62,17 +62,6 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 	return resp.ID, nil
 }
 
-func processVolumes(volumes []string) []string {
-	newVols := make([]string, 0)
-	for _, v := range volumes {
-		if v != "" {
-			newVols = append(newVols, v)
-		}
-	}
-
-	return newVols
-}
-
 func createServer(verbose bool, image string, apiPort string, args []string, env []string,
 	name string, volumes []string, nodeToPortSpecMap map[string][]string) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
@@ -107,7 +96,7 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 	}
 
 	if len(volumes) > 0 {
-		hostConfig.Binds = processVolumes(volumes)
+		hostConfig.Binds = volumes
 	}
 
 	networkingConfig := &network.NetworkingConfig{
@@ -173,7 +162,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
-		hostConfig.Binds = processVolumes(volumes)
+		hostConfig.Binds = volumes
 	}
 
 	networkingConfig := &network.NetworkingConfig{
@@ -210,7 +199,7 @@ func removeContainer(ID string) error {
 
 	options := types.ContainerRemoveOptions{
 		RemoveVolumes: true,
-		Force:true,
+		Force:         true,
 	}
 
 	if err := docker.ContainerRemove(ctx, ID, options); err != nil {

--- a/cli/container.go
+++ b/cli/container.go
@@ -62,6 +62,17 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 	return resp.ID, nil
 }
 
+func processVolumes(volumes []string) []string {
+	newVols := make([]string, 0)
+	for _, v := range volumes {
+		if v != "" {
+			newVols = append(newVols, v)
+		}
+	}
+
+	return newVols
+}
+
 func createServer(verbose bool, image string, apiPort string, args []string, env []string,
 	name string, volumes []string, nodeToPortSpecMap map[string][]string) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
@@ -96,7 +107,7 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
-		hostConfig.Binds = volumes
+		hostConfig.Binds = processVolumes(volumes)
 	}
 
 	networkingConfig := &network.NetworkingConfig{
@@ -162,7 +173,7 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
-		hostConfig.Binds = volumes
+		hostConfig.Binds = processVolumes(volumes)
 	}
 
 	networkingConfig := &network.NetworkingConfig{

--- a/cli/container.go
+++ b/cli/container.go
@@ -106,7 +106,7 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 		Privileged:   true,
 	}
 
-	if len(volumes) > 0 && volumes[0] != "" {
+	if len(volumes) > 0 {
 		hostConfig.Binds = processVolumes(volumes)
 	}
 


### PR DESCRIPTION
**What this PR does**: Adds support for ~~LUKS and LVM~~ btrfs mapped device users on linux. This is related to https://github.com/rancher/k3s/issues/471.

**Notes for my reviewer**: This might _not_ be the best way to do this, since this will likely fail on pure windows machines in the future (one day). I've tested this on machines w/ luks+lvm and machines w/o it.