### PR TITLE
[Feature] add `--hostnetwork` flag to connect cluster to host network

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -77,12 +77,17 @@ func CreateCluster(c *cli.Context) error {
 		image = fmt.Sprintf("%s/%s", defaultRegistry, image)
 	}
 
-	// create cluster network
-	networkID, err := createClusterNetwork(c.String("name"))
-	if err != nil {
-		return err
+	if c.IsSet("hostnetwork"){
+		// TODO: check if hostnetwork is available on the actual operating system
+		log.Printf("use network: `host`")
+	} else {
+		// create cluster network
+		networkID, err := createClusterNetwork(c.String("name"))
+		if err != nil {
+			return err
+		}
+		log.Printf("Created cluster network with ID %s", networkID)
 	}
-	log.Printf("Created cluster network with ID %s", networkID)
 
 	if c.IsSet("timeout") && !c.IsSet("wait") {
 		return errors.New("Cannot use --timeout flag without --wait flag")
@@ -126,6 +131,7 @@ func CreateCluster(c *cli.Context) error {
 		c.String("name"),
 		c.StringSlice("volume"),
 		portmap,
+		c.IsSet("hostnetwork"),
 	)
 	if err != nil {
 		log.Printf("ERROR: failed to create cluster\n%+v", err)
@@ -196,6 +202,7 @@ func CreateCluster(c *cli.Context) error {
 				c.String("api-port"),
 				portmap,
 				c.Int("port-auto-offset"),
+				c.IsSet("hostnetwork"),
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -77,10 +77,7 @@ func CreateCluster(c *cli.Context) error {
 		image = fmt.Sprintf("%s/%s", defaultRegistry, image)
 	}
 
-	if c.IsSet("hostnetwork"){
-		// TODO: check if hostnetwork is available on the actual operating system
-		log.Printf("use network: `host`")
-	} else {
+	if !c.IsSet("hostnetwork") || c.Int("workers") > 0 {
 		// create cluster network
 		networkID, err := createClusterNetwork(c.String("name"))
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -80,6 +80,10 @@ func main() {
 					Value: 6443,
 					Usage: "Map the Kubernetes ApiServer port to a local port (Note: --port/-p will be used for arbitrary port mapping as of v2.0.0, use --api-port/-a instead for setting the api port)",
 				},
+				cli.BoolFlag{
+					Name:  "hostnetwork, host",
+					Usage: "Use host network (only available on linux)",
+				},
 				cli.IntFlag{
 					Name:  "timeout, t",
 					Value: 0,


### PR DESCRIPTION
Add option to use the `host` network for the the server node to make LB/ingress connectivity accessible without additional port mappings.