### PR TITLE
[Enhancement] Make list command always show all clusters. Remove --all option

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -86,7 +86,7 @@ func getClusterDir(name string) (string, error) {
 }
 
 // printClusters prints the names of existing clusters
-func printClusters(all bool) {
+func printClusters() {
 	clusters, err := getClusters(true, "")
 	if err != nil {
 		log.Fatalf("ERROR: Couldn't list clusters\n%+v", err)
@@ -100,8 +100,6 @@ func printClusters(all bool) {
 	table.SetAlignment(tablewriter.ALIGN_CENTER)
 	table.SetHeader([]string{"NAME", "IMAGE", "STATUS", "WORKERS"})
 
-	tableEmpty := true
-
 	for _, cluster := range clusters {
 		workersRunning := 0
 		for _, worker := range cluster.workers {
@@ -111,15 +109,10 @@ func printClusters(all bool) {
 		}
 		workerData := fmt.Sprintf("%d/%d", workersRunning, len(cluster.workers))
 		clusterData := []string{cluster.name, cluster.image, cluster.status, workerData}
-		if cluster.status == "running" || all {
-			table.Append(clusterData)
-			tableEmpty = false
-		}
+		table.Append(clusterData)
 	}
 
-	if !tableEmpty {
-		table.Render()
-	}
+	table.Render()
 }
 
 // Classify cluster state: Running, Stopped or Abnormal

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -331,7 +331,11 @@ func StartCluster(c *cli.Context) error {
 
 // ListClusters prints a list of created clusters
 func ListClusters(c *cli.Context) error {
-	printClusters(c.Bool("all"))
+	if c.IsSet("all") {
+		log.Println("INFO: --all is on by default, thus no longer required. This option will be removed in v2.0.0")
+
+	}
+	printClusters()
 	return nil
 }
 


### PR DESCRIPTION
It feels more natural to have the list command show all clusters by
default.

@zeerorg asked a question in the same area in #33.  I agree with his question as well. 

I often forgot to add --all flag and find myself wondering what happened to the stopped clusters.