### PR TITLE
Prepare release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,7 @@ Here, we're tracking changes that belong to specific releases/tags
 ## v2.0.0
 
 * [DEPRECATION] `--version` flag for `k3d create` was removed in favor of `--image`/`-i` flag (Format: `--image [<repo>/]<image>:<tag>`), where you can include the image version/tag
+* [CHANGE] specifying the ApiPort is now only possible via the new `--api-port`/`-a` flag (`--port`/`-p` is being re-used for different functionality, see below)
+* [CHANGE] `--port`/`-p` is now an alias for `--publish`, used for mapping arbitrary ports from the host to the cluster containers
+    * [DEPRECATION] `--add-port` got removed as an alias for `--publish`
 * 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+Here, we're tracking changes that belong to specific releases/tags
+
+## v2.0.0
+
+* [DEPRECATION] `--version` flag for `k3d create` was removed in favor of `--image`/`-i` flag (Format: `--image [<repo>/]<image>:<tag>`), where you can include the image version/tag
+* 

--- a/README.md
+++ b/README.md
@@ -46,87 +46,10 @@ Example Workflow: Create a new cluster and use it with `kubectl`
 3. execute some commands like `kubectl get pods --all-namespaces`
 4. `k3d delete` to delete the default cluster
 
-### Expose services
+## What now?
 
-#### 1. via Ingress
+Find...
 
-1. Create a cluster, mapping the ingress port 80 to localhost:8081
-
-    `k3d create --api-port 6550 --publish 8081:80 --workers 2`
-
-    - Note: `--api-port 6550` is not required for the example to work. It's used to have `k3s`'s ApiServer listening on port 6550 with that port mapped to the host system.
-
-2. Get the kubeconfig file
-
-    `export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"`
-
-3. Create a nginx deployment
-
-    `kubectl create deployment nginx --image=nginx`
-
-4. Create a ClusterIP service for it
-
-    `kubectl create service clusterip nginx --tcp=80:80`
-
-5. Create an ingress object for it with `kubectl apply -f`
-
-    ```YAML
-    apiVersion: extensions/v1beta1
-    kind: Ingress
-    metadata:
-      name: nginx
-      annotations:
-        ingress.kubernetes.io/ssl-redirect: "false"
-    spec:
-      rules:
-      - http:
-          paths:
-          - path: /
-            backend:
-              serviceName: nginx
-              servicePort: 80
-    ```
-
-6. Curl it via localhost
-
-    `curl localhost:8081/`
-
-#### 2. via NodePort
-
-1. Create a cluster, mapping the port 30080 from worker-0 to localhost:8082
-
-    `k3d create --publish 8082:30080@k3d-k3s-default-worker-0 --workers 2`
-
-    - Note: Kubernetes' default NodePort range is [`30000-32767`](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
-
-... (Steps 2 and 3 like above) ...
-
-1. Create a NodePort service for it with `kubectl apply -f`
-
-    ```YAML
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: nginx
-      name: nginx
-    spec:
-      ports:
-      - name: 80-80
-        nodePort: 30080
-        port: 80
-        protocol: TCP
-        targetPort: 80
-      selector:
-        app: nginx
-      type: NodePort
-    ```
-
-2. Curl it via localhost
-
-    `curl localhost:8082/`
-
-## FAQ / Nice to know
-
-- As [@jaredallard](https://github.com/jaredallard) [pointed out](https://github.com/rancher/k3d/pull/48), people running `k3d` on Linux with **LUKS/LVM**, may need to mount `/dev/mapper` into the nodes for the setup to work.
-  - This will do: `k3d create -v /dev/mapper:/dev/mapper`
+- [... further documentation here](docs/documentation.md)
+- [... usage examples here](docs/examples.md)
+- [... frequently asked questions and nice-to-know facts here](docs/faq.md)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -61,17 +61,6 @@ func CreateCluster(c *cli.Context) error {
 
 	// define image
 	image := c.String("image")
-	if c.IsSet("version") {
-		// TODO: --version to be deprecated
-		log.Println("[WARNING] The `--version` flag will be deprecated soon, please use `--image rancher/k3s:<version>` instead")
-		if c.IsSet("image") {
-			// version specified, custom image = error (to push deprecation of version flag)
-			log.Fatalln("[ERROR] Please use `--image <image>:<version>` instead of --image and --version")
-		} else {
-			// version specified, default image = ok (until deprecation of version flag)
-			image = fmt.Sprintf("%s:%s", strings.Split(image, ":")[0], c.String("version"))
-		}
-	}
 	if len(strings.Split(image, "/")) <= 2 {
 		// fallback to default registry
 		image = fmt.Sprintf("%s/%s", defaultRegistry, image)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -89,17 +89,13 @@ func CreateCluster(c *cli.Context) error {
 	}
 
 	// k3s server arguments
-	// TODO: --port will soon be --api-port since we want to re-use --port for arbitrary port mappings
-	if c.IsSet("port") {
-		log.Println("INFO: As of v2.0.0 --port will be used for arbitrary port mapping. Please use --api-port/-a instead for configuring the Api Port")
-	}
 	k3sServerArgs := []string{"--https-listen-port", c.String("api-port")}
 	if c.IsSet("server-arg") || c.IsSet("x") {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
 	// new port map
-	portmap, err := mapNodesToPortSpecs(c.StringSlice("publish"), GetAllContainerNames(c.String("name"), defaultServerCount, c.Int("workers")))
+	portmap, err := mapNodesToPortSpecs(c.StringSlice("port"), GetAllContainerNames(c.String("name"), defaultServerCount, c.Int("workers")))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,5 @@
+# Documentation
+
+## Compatibility with `k3s` functionality/options
+
+... under construction ...

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,5 +1,25 @@
 # Documentation
 
+## Functionality
+
+```shell
+COMMANDS:
+     check-tools, ct  Check if docker is running
+     create, c        Create a single- or multi-node k3s cluster in docker containers
+     delete, d, del   Delete cluster
+     stop             Stop cluster
+     start            Start a stopped cluster
+     list, ls, l      List all clusters
+     get-kubeconfig   Get kubeconfig location for cluster
+     help, h          Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --verbose      Enable verbose output
+   --help, -h     show help
+   --version, -v  print the version
+```
+
+
 ## Compatibility with `k3s` functionality/options
 
 ... under construction ...

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,81 @@
+# Examples
+
+## Expose services
+
+### 1. via Ingress
+
+1. Create a cluster, mapping the ingress port 80 to localhost:8081
+
+    `k3d create --api-port 6550 --publish 8081:80 --workers 2`
+
+    - Note: `--api-port 6550` is not required for the example to work. It's used to have `k3s`'s ApiServer listening on port 6550 with that port mapped to the host system.
+
+2. Get the kubeconfig file
+
+    `export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"`
+
+3. Create a nginx deployment
+
+    `kubectl create deployment nginx --image=nginx`
+
+4. Create a ClusterIP service for it
+
+    `kubectl create service clusterip nginx --tcp=80:80`
+
+5. Create an ingress object for it with `kubectl apply -f`
+
+    ```YAML
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: nginx
+      annotations:
+        ingress.kubernetes.io/ssl-redirect: "false"
+    spec:
+      rules:
+      - http:
+          paths:
+          - path: /
+            backend:
+              serviceName: nginx
+              servicePort: 80
+    ```
+
+6. Curl it via localhost
+
+    `curl localhost:8081/`
+
+### 2. via NodePort
+
+1. Create a cluster, mapping the port 30080 from worker-0 to localhost:8082
+
+    `k3d create --publish 8082:30080@k3d-k3s-default-worker-0 --workers 2`
+
+    - Note: Kubernetes' default NodePort range is [`30000-32767`](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
+
+... (Steps 2 and 3 like above) ...
+
+1. Create a NodePort service for it with `kubectl apply -f`
+
+    ```YAML
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: nginx
+      name: nginx
+    spec:
+      ports:
+      - name: 80-80
+        nodePort: 30080
+        port: 80
+        protocol: TCP
+        targetPort: 80
+      selector:
+        app: nginx
+      type: NodePort
+    ```
+
+2. Curl it via localhost
+
+    `curl localhost:8082/`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,4 @@
+# FAQ / Nice to know
+
+- As [@jaredallard](https://github.com/jaredallard) [pointed out](https://github.com/rancher/k3d/pull/48), people running `k3d` on a system with **btrfs**, may need to mount `/dev/mapper` into the nodes for the setup to work.
+  - This will do: `k3d create -v /dev/mapper:/dev/mapper`

--- a/main.go
+++ b/main.go
@@ -74,11 +74,6 @@ func main() {
 					Value: 0,
 					Usage: "Automatically add an offset (* worker number) to the chosen host port when using `--publish` to map the same container-port from multiple k3d workers to the host",
 				},
-				cli.StringFlag{
-					// TODO: to be deprecated
-					Name:  "version",
-					Usage: "Choose the k3s image version",
-				},
 				cli.IntFlag{
 					// TODO: only --api-port, -a soon since we want to use --port, -p for the --publish/--add-port functionality
 					Name:  "api-port, a, port, p",
@@ -96,7 +91,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "image, i",
-					Usage: "Specify a k3s image (Format: <repo>/<image>:<tag>)",
+					Usage: "Specify a k3s image (Format: [<repo>/]<image>:<tag>, default repo is docker.io)",
 					Value: fmt.Sprintf("%s:%s", defaultK3sImage, version.GetK3sVersion()),
 				},
 				cli.StringSliceFlag{

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 					Usage: "Mount one or more volumes into every node of the cluster (Docker notation: `source:destination`)",
 				},
 				cli.StringSliceFlag{
-					Name:  "publish, add-port",
+					Name:  "port, p, publish",
 					Usage: "Publish k3s node ports to the host (Format: `[ip:][host-port:]container-port[/protocol]@node-specifier`, use multiple options to expose more ports)",
 				},
 				cli.IntFlag{
@@ -75,10 +75,9 @@ func main() {
 					Usage: "Automatically add an offset (* worker number) to the chosen host port when using `--publish` to map the same container-port from multiple k3d workers to the host",
 				},
 				cli.IntFlag{
-					// TODO: only --api-port, -a soon since we want to use --port, -p for the --publish/--add-port functionality
-					Name:  "api-port, a, port, p",
+					Name:  "api-port, a",
 					Value: 6443,
-					Usage: "Map the Kubernetes ApiServer port to a local port (Note: --port/-p will be used for arbitrary port mapping as of v2.0.0, use --api-port/-a instead for setting the api port)",
+					Usage: "Map the Kubernetes ApiServer port to a local port",
 				},
 				cli.IntFlag{
 					Name:  "timeout, t",

--- a/main.go
+++ b/main.go
@@ -32,7 +32,12 @@ func main() {
 			Email: "r.g.gupta@outlook.com",
 		},
 		{
-			Name: "Darren Shepherd",
+			Name:  "Darren Shepherd",
+			Email: "darren@rancher.com",
+		},
+		{
+			Name:  "Andy Zhou",
+			Email: "andy@andyz.dev",
 		},
 	}
 


### PR DESCRIPTION
This PR should prepare the project for release v2.0.0.
This includes some deprecations and changes to some flags.

Also, I started moving the different parts of documentation from the readme to separate files, so we can easily enhance them in the future.