### PR TITLE
[Enhancement] Atomic create

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -198,7 +198,12 @@ func CreateCluster(c *cli.Context) error {
 				c.Int("port-auto-offset"),
 			)
 			if err != nil {
-				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)
+				log.Printf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)
+				delErr := DeleteCluster(c)
+				if delErr != nil {
+					return delErr
+				}
+				os.Exit(1)
 			}
 			log.Printf("Created worker with ID %s\n", workerID)
 		}


### PR DESCRIPTION
Before this commit, when creating a cluster was not successful, some
resource may be lingering behind. This commit fixes those cases.

Now the cluster creation model is easier to understand. Either a cluster
is successfully created, or all resources created will be cleaned up.

The intention is to keep the "atomic create" model going forward for
k3d.