### PR TITLE
[Feature] Implement --always-on flag for the create command

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -126,6 +126,7 @@ func CreateCluster(c *cli.Context) error {
 		c.String("name"),
 		c.StringSlice("volume"),
 		portmap,
+		c.Bool("auto-restart"),
 	)
 	if err != nil {
 		log.Printf("ERROR: failed to create cluster\n%+v", err)
@@ -196,6 +197,7 @@ func CreateCluster(c *cli.Context) error {
 				c.String("api-port"),
 				portmap,
 				c.Int("port-auto-offset"),
+				c.Bool("auto-restart"),
 			)
 			if err != nil {
 				return fmt.Errorf("ERROR: failed to create worker node for cluster %s\n%+v", c.String("name"), err)

--- a/cli/container.go
+++ b/cli/container.go
@@ -63,7 +63,7 @@ func startContainer(verbose bool, config *container.Config, hostConfig *containe
 }
 
 func createServer(verbose bool, image string, apiPort string, args []string, env []string,
-	name string, volumes []string, nodeToPortSpecMap map[string][]string) (string, error) {
+	name string, volumes []string, nodeToPortSpecMap map[string][]string, autoRestart bool) (string, error) {
 	log.Printf("Creating server using %s...\n", image)
 
 	containerLabels := make(map[string]string)
@@ -93,6 +93,10 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 	hostConfig := &container.HostConfig{
 		PortBindings: serverPublishedPorts.PortBindings,
 		Privileged:   true,
+	}
+
+	if autoRestart {
+		hostConfig.RestartPolicy.Name = "unless-stopped"
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {
@@ -125,7 +129,7 @@ func createServer(verbose bool, image string, apiPort string, args []string, env
 
 // createWorker creates/starts a k3s agent node that connects to the server
 func createWorker(verbose bool, image string, args []string, env []string, name string, volumes []string,
-	postfix int, serverPort string, nodeToPortSpecMap map[string][]string, portAutoOffset int) (string, error) {
+	postfix int, serverPort string, nodeToPortSpecMap map[string][]string, portAutoOffset int, autoRestart bool) (string, error) {
 	containerLabels := make(map[string]string)
 	containerLabels["app"] = "k3d"
 	containerLabels["component"] = "worker"
@@ -159,6 +163,10 @@ func createWorker(verbose bool, image string, args []string, env []string, name 
 		},
 		PortBindings: workerPublishedPorts.PortBindings,
 		Privileged:   true,
+	}
+
+	if autoRestart {
+		hostConfig.RestartPolicy.Name = "unless-stopped"
 	}
 
 	if len(volumes) > 0 && volumes[0] != "" {

--- a/main.go
+++ b/main.go
@@ -107,6 +107,10 @@ func main() {
 					Value: 0,
 					Usage: "Specify how many worker nodes you want to spawn",
 				},
+				cli.BoolFlag{
+					Name:  "auto-restart",
+					Usage: "Set docker's --restart=unless-stopped flag on the containers",
+				},
 			},
 			Action: run.CreateCluster,
 		},


### PR DESCRIPTION
As mentioned in #15. 

When creating clusters with the --always-on flag, the cluster can
remain in the "running" state across the docker daemon restart.

Without this flag, a "running" cluster becomes "stopped" after docker
daemon restart.

Clusters stopped with 'k3d stop' command will remain stopped after
docker daemon restart.