### PR TITLE
[Feature] Add Bash shell support

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -85,6 +85,11 @@ func getClusterDir(name string) (string, error) {
 	return path.Join(homeDir, ".config", "k3d", name), nil
 }
 
+func getClusterKubeConfigPath(cluster string) (string, error) {
+	clusterDir, err := getClusterDir(cluster)
+	return path.Join(clusterDir, "kubeconfig.yaml"), err
+}
+
 // printClusters prints the names of existing clusters
 func printClusters() {
 	clusters, err := getClusters(true, "")

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -148,6 +148,31 @@ func createKubeConfigFile(cluster string) error {
 	return nil
 }
 
+func getKubeConfig(cluster string) (string, error) {
+	kubeConfigPath, err := getClusterKubeConfigPath(cluster)
+	if err != nil {
+		return "", err
+	}
+
+	if clusters, err := getClusters(false, cluster); err != nil || len(clusters) != 1 {
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("Cluster %s does not exist", cluster)
+	}
+
+	// If kubeconfig.yaml has not been created, generate it now
+	if _, err := os.Stat(kubeConfigPath); os.IsNotExist(err) {
+		if err = createKubeConfigFile(cluster); err != nil {
+			return "", err
+		}
+	} else {
+		return "", err
+	}
+
+	return kubeConfigPath, nil
+}
+
 // printClusters prints the names of existing clusters
 func printClusters() {
 	clusters, err := getClusters(true, "")

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -161,13 +161,15 @@ func getKubeConfig(cluster string) (string, error) {
 		return "", fmt.Errorf("Cluster %s does not exist", cluster)
 	}
 
-	// If kubeconfig.yaml has not been created, generate it now
-	if _, err := os.Stat(kubeConfigPath); os.IsNotExist(err) {
-		if err = createKubeConfigFile(cluster); err != nil {
+	// If kubeconfi.yaml has not been created, generate it now
+	if _, err := os.Stat(kubeConfigPath); err != nil {
+		if os.IsNotExist(err) {
+			if err = createKubeConfigFile(cluster); err != nil {
+				return "", err
+			}
+		} else {
 			return "", err
 		}
-	} else {
-		return "", err
 	}
 
 	return kubeConfigPath, nil

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -1,8 +1,10 @@
 package run
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -88,6 +90,62 @@ func getClusterDir(name string) (string, error) {
 func getClusterKubeConfigPath(cluster string) (string, error) {
 	clusterDir, err := getClusterDir(cluster)
 	return path.Join(clusterDir, "kubeconfig.yaml"), err
+}
+
+func createKubeConfigFile(cluster string) error {
+	ctx := context.Background()
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+
+	filters := filters.NewArgs()
+	filters.Add("label", "app=k3d")
+	filters.Add("label", fmt.Sprintf("cluster=%s", cluster))
+	filters.Add("label", "component=server")
+	server, err := docker.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Failed to get server container for cluster %s\n%+v", cluster, err)
+	}
+
+	if len(server) == 0 {
+		return fmt.Errorf("No server container for cluster %s", cluster)
+	}
+
+	// get kubeconfig file from container and read contents
+	reader, _, err := docker.CopyFromContainer(ctx, server[0].ID, "/output/kubeconfig.yaml")
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't copy kubeconfig.yaml from server container %s\n%+v", server[0].ID, err)
+	}
+	defer reader.Close()
+
+	readBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't read kubeconfig from container\n%+v", err)
+	}
+
+	// create destination kubeconfig file
+	destPath, err := getClusterKubeConfigPath(cluster)
+	if err != nil {
+		return err
+	}
+
+	kubeconfigfile, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't create kubeconfig file %s\n%+v", destPath, err)
+	}
+	defer kubeconfigfile.Close()
+
+	// write to file, skipping the first 512 bytes which contain file metadata and trimming any NULL characters
+	_, err = kubeconfigfile.Write(bytes.Trim(readBytes[512:], "\x00"))
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't write to kubeconfig.yaml\n%+v", err)
+	}
+
+	return nil
 }
 
 // printClusters prints the names of existing clusters

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -354,6 +354,6 @@ func GetKubeConfig(c *cli.Context) error {
 	return nil
 }
 
-func Bash(c *cli.Context) error {
+func Shell(c *cli.Context) error {
 	return bashShell(c.String("name"), c.String("command"))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -355,5 +355,9 @@ func GetKubeConfig(c *cli.Context) error {
 }
 
 func Shell(c *cli.Context) error {
+	if c.String("shell") != "bash" {
+		return fmt.Errorf("%s is not supported. Only bash is supported", c.String("shell"))
+	}
+
 	return bashShell(c.String("name"), c.String("command"))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -353,3 +353,7 @@ func GetKubeConfig(c *cli.Context) error {
 	fmt.Println(kubeConfigPath)
 	return nil
 }
+
+func Bash(c *cli.Context) error {
+	return bashShell(c.String("name"))
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -9,14 +9,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/docker/docker/api/types/filters"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -346,60 +343,29 @@ func ListClusters(c *cli.Context) error {
 
 // GetKubeConfig grabs the kubeconfig from the running cluster and prints the path to stdout
 func GetKubeConfig(c *cli.Context) error {
-	ctx := context.Background()
-	docker, err := client.NewEnvClient()
-	if err != nil {
-		return err
-	}
-
-	filters := filters.NewArgs()
-	filters.Add("label", "app=k3d")
-	filters.Add("label", fmt.Sprintf("cluster=%s", c.String("name")))
-	filters.Add("label", "component=server")
-	server, err := docker.ContainerList(ctx, types.ContainerListOptions{
-		Filters: filters,
-	})
-
-	if err != nil {
-		return fmt.Errorf("Failed to get server container for cluster %s\n%+v", c.String("name"), err)
-	}
-
-	if len(server) == 0 {
-		return fmt.Errorf("No server container for cluster %s", c.String("name"))
-	}
-
-	// get kubeconfig file from container and read contents
-	reader, _, err := docker.CopyFromContainer(ctx, server[0].ID, "/output/kubeconfig.yaml")
-	if err != nil {
-		return fmt.Errorf("ERROR: couldn't copy kubeconfig.yaml from server container %s\n%+v", server[0].ID, err)
-	}
-	defer reader.Close()
-
-	readBytes, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return fmt.Errorf("ERROR: couldn't read kubeconfig from container\n%+v", err)
-	}
-
-	// create destination kubeconfig file
+	cluster := c.String("name")
 	destPath, err := getClusterKubeConfigPath(c.String("name"))
 	if err != nil {
 		return err
 	}
 
-	kubeconfigfile, err := os.Create(destPath)
-	if err != nil {
-		return fmt.Errorf("ERROR: couldn't create kubeconfig file %s\n%+v", destPath, err)
+	if clusters, err := getClusters(false, cluster); err != nil || len(clusters) != 1 {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("Cluster %s does not exist", cluster)
 	}
-	defer kubeconfigfile.Close()
 
-	// write to file, skipping the first 512 bytes which contain file metadata and trimming any NULL characters
-	_, err = kubeconfigfile.Write(bytes.Trim(readBytes[512:], "\x00"))
-	if err != nil {
-		return fmt.Errorf("ERROR: couldn't write to kubeconfig.yaml\n%+v", err)
+	// If kubeconfig.yaml has not been created, generate it now.
+	if _, err := os.Stat(destPath); os.IsNotExist(err) {
+		if err = createKubeConfigFile(cluster); err != nil {
+			return err
+		}
+	} else {
+		return err
 	}
 
 	// output kubeconfig file path to stdout
 	fmt.Println(destPath)
-
 	return nil
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -355,5 +355,5 @@ func GetKubeConfig(c *cli.Context) error {
 }
 
 func Bash(c *cli.Context) error {
-	return bashShell(c.String("name"))
+	return bashShell(c.String("name"), c.String("command"))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -381,15 +381,14 @@ func GetKubeConfig(c *cli.Context) error {
 	}
 
 	// create destination kubeconfig file
-	clusterDir, err := getClusterDir(c.String("name"))
-	destPath := fmt.Sprintf("%s/kubeconfig.yaml", clusterDir)
+	destPath, err := getClusterKubeConfigPath(c.String("name"))
 	if err != nil {
 		return err
 	}
 
 	kubeconfigfile, err := os.Create(destPath)
 	if err != nil {
-		return fmt.Errorf("ERROR: couldn't create kubeconfig.yaml in %s\n%+v", clusterDir, err)
+		return fmt.Errorf("ERROR: couldn't create kubeconfig file %s\n%+v", destPath, err)
 	}
 	defer kubeconfigfile.Close()
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -344,28 +344,12 @@ func ListClusters(c *cli.Context) error {
 // GetKubeConfig grabs the kubeconfig from the running cluster and prints the path to stdout
 func GetKubeConfig(c *cli.Context) error {
 	cluster := c.String("name")
-	destPath, err := getClusterKubeConfigPath(c.String("name"))
+	kubeConfigPath, err := getKubeConfig(cluster)
 	if err != nil {
 		return err
 	}
 
-	if clusters, err := getClusters(false, cluster); err != nil || len(clusters) != 1 {
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("Cluster %s does not exist", cluster)
-	}
-
-	// If kubeconfig.yaml has not been created, generate it now.
-	if _, err := os.Stat(destPath); os.IsNotExist(err) {
-		if err = createKubeConfigFile(cluster); err != nil {
-			return err
-		}
-	} else {
-		return err
-	}
-
 	// output kubeconfig file path to stdout
-	fmt.Println(destPath)
+	fmt.Println(kubeConfigPath)
 	return nil
 }

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-func bashShell(cluster string) error {
+func bashShell(cluster string, command string) error {
 	kubeConfigPath, err := getKubeConfig(cluster)
 	if err != nil {
 		return err
@@ -18,6 +18,11 @@ func bashShell(cluster string) error {
 	}
 
 	cmd := exec.Command(bashPath, "--noprofile", "--norc")
+
+	if len(command) > 0 {
+		cmd.Args = append(cmd.Args, "-c", command)
+
+	}
 
 	// Set up stdio
 	cmd.Stdout = os.Stdout

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -12,6 +12,11 @@ func bashShell(cluster string, command string) error {
 		return err
 	}
 
+	subShell := os.ExpandEnv("$__K3D_CLUSTER__")
+	if len(subShell) > 0 {
+		return fmt.Errorf("Error: Already in subshell of cluster %s", subShell)
+	}
+
 	bashPath, err := exec.LookPath("bash")
 	if err != nil {
 		return err
@@ -34,7 +39,11 @@ func bashShell(cluster string, command string) error {
 
 	// Set up KUBECONFIG
 	setKube := fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath)
-	newEnv := append(os.Environ(), setPS1, setKube)
+
+	// Declare subshell
+	subShell = fmt.Sprintf("__K3D_CLUSTER__=%s", cluster)
+
+	newEnv := append(os.Environ(), setPS1, setKube, subShell)
 
 	cmd.Env = newEnv
 

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -1,0 +1,31 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func bashShell(cluster string) error {
+	kubeConfigPath, err := getKubeConfig(cluster)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("/bin/bash", "--noprofile", "--norc")
+
+	// Set up stdio
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	// Set up Promot
+	setPS1 := fmt.Sprintf("PS1=[%s}%s", cluster, os.Getenv("PS1"))
+
+	// Set up KUBECONFIG
+	setKube := fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath)
+	newEnv := append(os.Environ(), setPS1, setKube)
+
+	cmd.Env = newEnv
+
+	return cmd.Run()
+}

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -11,7 +11,13 @@ func bashShell(cluster string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("/bin/bash", "--noprofile", "--norc")
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(bashPath, "--noprofile", "--norc")
 
 	// Set up stdio
 	cmd.Stdout = os.Stdout

--- a/main.go
+++ b/main.go
@@ -55,6 +55,10 @@ func main() {
 					Value: defaultK3sClusterName,
 					Usage: "Set a name for the cluster",
 				},
+				cli.StringFlag{
+					Name:  "command, c",
+					Usage: "Run a shell command in the context of the cluster",
+				},
 			},
 			Action: run.Bash,
 		},

--- a/main.go
+++ b/main.go
@@ -59,6 +59,11 @@ func main() {
 					Name:  "command, c",
 					Usage: "Run a shell command in the context of the cluster",
 				},
+				cli.StringFlag{
+					Name:  "shell, s",
+					Value: "bash",
+					Usage: "Sub shell type. Only bash is supported. (default bash)",
+				},
 			},
 			Action: run.Shell,
 		},

--- a/main.go
+++ b/main.go
@@ -46,9 +46,9 @@ func main() {
 			Action:  run.CheckTools,
 		},
 		{
-			// bash starts a bash shell in the context of a runnign cluster
-			Name:  "bash",
-			Usage: "Start a bash subshell for a cluster",
+			// shell starts a shell in the context of a running cluster
+			Name:  "shell",
+			Usage: "Start a subshell for a cluster",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
@@ -60,7 +60,7 @@ func main() {
 					Usage: "Run a shell command in the context of the cluster",
 				},
 			},
-			Action: run.Bash,
+			Action: run.Shell,
 		},
 		{
 			// create creates a new k3s cluster in docker containers

--- a/main.go
+++ b/main.go
@@ -46,6 +46,19 @@ func main() {
 			Action:  run.CheckTools,
 		},
 		{
+			// bash starts a bash shell in the context of a runnign cluster
+			Name:  "bash",
+			Usage: "Start a bash subshell for a cluster",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "name, n",
+					Value: defaultK3sClusterName,
+					Usage: "Set a name for the cluster",
+				},
+			},
+			Action: run.Bash,
+		},
+		{
 			// create creates a new k3s cluster in docker containers
 			Name:    "create",
 			Aliases: []string{"c"},


### PR DESCRIPTION
After creating a cluster, k3d will display a hint on how to set the KUBECONFIG. Often the message scrolled away, and one has to either remember the syntax or hunt for the message. 

This PR implemented the 'bash' subcommand to make switch between cluster context easier.

To start a new shell with a cluster context do:
  $ k3d bash -n <cluster-name> 

This will gave a new shell with KUBECONFIG set for the cluster. kubectl will just work with the intended cluster.  Use  'exit' to leave the shell

Also support a one liner use cases:

   $ k3d bash -n <cluster-name> -e 'kubectl cluster-info' 

This is useful to quick issue commands against multiple clusters.

Limitations: 
* The PR only support bash,  If it is useful, I hope others will contribute support for more shells.


