### PR TITLE
[Feature] auto mode and zsh support for shell command

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -356,5 +356,5 @@ func GetKubeConfig(c *cli.Context) error {
 
 // Shell starts a new subshell with the KUBECONFIG pointing to the selected cluster
 func Shell(c *cli.Context) error {
-	return shell(c.String("name"), c.String("shell"), c.String("command"))
+	return subShell(c.String("name"), c.String("shell"), c.String("command"))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -354,10 +354,7 @@ func GetKubeConfig(c *cli.Context) error {
 	return nil
 }
 
+// Shell starts a new subshell with the KUBECONFIG pointing to the selected cluster
 func Shell(c *cli.Context) error {
-	if c.String("shell") != "bash" {
-		return fmt.Errorf("%s is not supported. Only bash is supported", c.String("shell"))
-	}
-
-	return bashShell(c.String("name"), c.String("command"))
+	return shell(c.String("name"), c.String("shell"), c.String("command"))
 }

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -4,25 +4,63 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 )
 
-func bashShell(cluster string, command string) error {
+var shells = map[string]map[string][]string{
+	"bash": {
+		"options": []string{
+			"--noprofile", // don't load .profile/.bash_profile
+			"--norc",      // don't load .bashrc
+		},
+	},
+	"zsh": {
+		"options": []string{
+			"--no-rcs", // don't load .zshrc
+		},
+	},
+}
+
+// shell
+func shell(cluster, shell, command string) error {
+
+	// check if the selected shell is supported
+	if shell == "auto" {
+		shell = path.Base(os.Getenv("SHELL"))
+	}
+
+	supported := false
+	for supportedShell := range shells {
+		if supportedShell == shell {
+			supported = true
+		}
+	}
+	if !supported {
+		return fmt.Errorf("ERROR: selected shell [%s] is not supported", shell)
+	}
+
+	// get kubeconfig for selected cluster
 	kubeConfigPath, err := getKubeConfig(cluster)
 	if err != nil {
 		return err
 	}
 
+	// check if we're already in a subshell
 	subShell := os.ExpandEnv("$__K3D_CLUSTER__")
 	if len(subShell) > 0 {
 		return fmt.Errorf("Error: Already in subshell of cluster %s", subShell)
 	}
 
-	bashPath, err := exec.LookPath("bash")
+	// get path of shell executable
+	shellPath, err := exec.LookPath(shell)
 	if err != nil {
 		return err
 	}
 
-	cmd := exec.Command(bashPath, "--noprofile", "--norc")
+	// set shell specific options (command line flags)
+	shellOptions := shells[shell]["options"]
+
+	cmd := exec.Command(shellPath, shellOptions...)
 
 	if len(command) > 0 {
 		cmd.Args = append(cmd.Args, "-c", command)

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -84,7 +84,7 @@ func subShell(cluster, shell, command string) error {
 	cmd.Stderr = os.Stderr
 
 	// Set up Promot
-	setPrompt := fmt.Sprintf("%s=[%s} %s", shells[shell].Prompt, cluster, os.Getenv("PS1"))
+	setPrompt := fmt.Sprintf("%s=[%s} %s", shells[shell].Prompt, cluster, shells[shell].Prompt)
 
 	// Set up KUBECONFIG
 	setKube := fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath)

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -84,7 +84,7 @@ func subShell(cluster, shell, command string) error {
 	cmd.Stderr = os.Stderr
 
 	// Set up Promot
-	setPrompt := fmt.Sprintf("%s=[%s} %s", shells[shell].Prompt, cluster, shells[shell].Prompt)
+	setPrompt := fmt.Sprintf("%s=[%s} %s", shells[shell].Prompt, cluster, os.Getenv(shells[shell].Prompt))
 
 	// Set up KUBECONFIG
 	setKube := fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "shell, s",
-					Value: "bash",
+					Value: "auto",
 					Usage: "Sub shell type. Only bash is supported. (default bash)",
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "shell, s",
 					Value: "auto",
-					Usage: "Sub shell type. Only bash is supported. (default bash)",
+					Usage: "which shell to use. One of [auto, bash, zsh]",
 				},
 			},
 			Action: run.Shell,


### PR DESCRIPTION
By default, the `shell` command now uses `auto`-mode, where it selects the shell based on the `$SHELL` environment variable. It then checks if that shell is supported and selects the required options from a map.
I also added support (options) for `zsh`.