### PR TITLE
[Feature] Docker machine

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -139,8 +140,23 @@ func createKubeConfigFile(cluster string) error {
 	}
 	defer kubeconfigfile.Close()
 
-	// write to file, skipping the first 512 bytes which contain file metadata and trimming any NULL characters
-	_, err = kubeconfigfile.Write(bytes.Trim(readBytes[512:], "\x00"))
+	// write to file, skipping the first 512 bytes which contain file metadata
+	// and trimming any NULL characters
+	trimBytes := bytes.Trim(readBytes[512:], "\x00")
+
+	// If running on a docker machine, replace localhost with
+	// docker machine's IP
+	dockerMachineIp, err := getDockerMachineIp()
+	if err != nil {
+		return err
+	}
+
+	if dockerMachineIp != "" {
+		s := string(trimBytes)
+		s = strings.Replace(s, "localhost", dockerMachineIp, 1)
+		trimBytes = []byte(s)
+	}
+	_, err = kubeconfigfile.Write(trimBytes)
 	if err != nil {
 		return fmt.Errorf("ERROR: couldn't write to kubeconfig.yaml\n%+v", err)
 	}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -106,6 +106,13 @@ func CreateCluster(c *cli.Context) error {
 		log.Println("INFO: As of v2.0.0 --port will be used for arbitrary port mapping. Please use --api-port/-a instead for configuring the Api Port")
 	}
 	k3sServerArgs := []string{"--https-listen-port", c.String("api-port")}
+	if ip, err := getDockerMachineIp(); ip != "" || err != nil {
+		if err != nil {
+			return err
+		}
+		log.Printf("Add TLS SAN for %s", ip)
+		k3sServerArgs = append(k3sServerArgs, "--tls-san", ip)
+	}
 	if c.IsSet("server-arg") || c.IsSet("x") {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}

--- a/cli/docker-machine.go
+++ b/cli/docker-machine.go
@@ -18,7 +18,7 @@ func getDockerMachineIp() (string, error) {
 		return "", err
 	}
 
-	out, err := exec.Command(dockerMachinePath, "ip").Output()
+	out, err := exec.Command(dockerMachinePath, "ip", machine).Output()
 
 	ipStr := strings.TrimSuffix(string(out), "\n")
 	ipStr = strings.TrimSuffix(ipStr, "\r")

--- a/cli/docker-machine.go
+++ b/cli/docker-machine.go
@@ -1,0 +1,26 @@
+package run
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func getDockerMachineIp() (string, error) {
+	machine := os.ExpandEnv("$DOCKER_MACHINE_NAME")
+
+	if machine == "" {
+		return "", nil
+	}
+
+	dockerMachinePath, err := exec.LookPath("docker-machine")
+	if err != nil {
+		return "", err
+	}
+
+	out, err := exec.Command(dockerMachinePath, "ip").Output()
+
+	ipStr := strings.TrimSuffix(string(out), "\n")
+	ipStr = strings.TrimSuffix(ipStr, "\r")
+	return ipStr, err
+}


### PR DESCRIPTION
Also should fix #68.

Docker Toolbox uses a docker-machine to run docker containers.  This bug exposes the fact k3d does not recognize docker machine in general.  This PR adds support for docker machine, thus should also fix #68.

I don't usually use Docker Toolbox, or other docker machine set up. This PR could benefit from more testing from those who do use them.