### PR TITLE
[Enhancement] Log more information when the docker-machine command fails

### DIFF
--- a/cli/docker-machine.go
+++ b/cli/docker-machine.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,8 +20,16 @@ func getDockerMachineIp() (string, error) {
 	}
 
 	out, err := exec.Command(dockerMachinePath, "ip", machine).Output()
+	if err != nil {
+		log.Printf("Error executing 'docker-machine ip'")
 
+		if exitError, ok := err.(*exec.ExitError); ok {
+			log.Printf("%s", string(exitError.Stderr))
+		}
+		return "", err
+	}
 	ipStr := strings.TrimSuffix(string(out), "\n")
 	ipStr = strings.TrimSuffix(ipStr, "\r")
-	return ipStr, err
+
+	return ipStr, nil
 }


### PR DESCRIPTION
Triggered by bug report #78.

Currently, when the 'docker-machine' command fails, we only logs

   "exit status 1'

Which is not very helpful in root cause analysis.

With this patch, the 'docker-machine' command's stderr output is also
logged.

  # To cause docker-machine command fail
  $ export DOCKER_MACHINE_NAME=xx
  $ k3d create
2019/06/13 16:45:31 Created cluster network with ID 6fc91e0e5e912443e6b847f113a6a0bb85ccd610e5232592296d4b199f0347cf
2019/06/13 16:45:31 Error executing 'docker-machine ip'
2019/06/13 16:45:31 Docker machine "xx" does not exist. Use "docker-machine ls" to list machines. Use "docker-machine create" to add a new one.
exit status 1