### PR TITLE
[Enhancement] Ignore docker-machine command line error

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -109,12 +109,14 @@ func CreateCluster(c *cli.Context) error {
 
 	// When the 'host' is not provided by --api-port, try to fill it using Docker Machine's IP address.
 	if apiPort.Host == "" {
-		if apiPort.Host, err = getDockerMachineIp(); err != nil {
-			return err
-		}
-
+		apiPort.Host, err = getDockerMachineIp()
 		// IP address is the same as the host
 		apiPort.HostIp = apiPort.Host
+		// In case of error, Log a warning message, and continue on. Since it more likely caused by a miss configured
+		// DOCKER_MACHINE_NAME environment variable.
+		if err != nil {
+			log.Printf("WARNING: Failed to get docker machine IP address, ignoring the DOCKER_MACHINE_NAME environment variable setting.\n")
+		}
 	}
 
 	if apiPort.Host != "" {


### PR DESCRIPTION
It turns out that docker client only pays attention to the following
environment variables:

DOCKER_HOST to set the url to the docker server.
DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
DOCKER_CERT_PATH to load the TLS certificates from.
DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.

A miss configured DOCKER_MACHINE_NAME won't affect docker client, so k3d
should just ignore the error.