### PR TITLE
Fix inverted timeout logic on create.

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -170,7 +170,7 @@ func CreateCluster(c *cli.Context) error {
 	timeout := time.Duration(c.Int("wait")) * time.Second
 	for c.IsSet("wait") {
 		// not running after timeout exceeded? Rollback and delete everything.
-		if timeout != 0 && !time.Now().After(start.Add(timeout)) {
+		if timeout != 0 && time.Now().After(start.Add(timeout)) {
 			deleteCluster()
 			return errors.New("Cluster creation exceeded specified timeout")
 		}


### PR DESCRIPTION
Fix for #87 - error should occur when current time is after start+timeout