### PR TITLE
[Feature] import images from docker daemon into k3d

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -14,8 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -68,6 +68,10 @@ func createClusterDir(name string) {
 	if err := createDirIfNotExists(clusterPath); err != nil {
 		log.Fatalf("ERROR: couldn't create cluster directory [%s] -> %+v", clusterPath, err)
 	}
+	// create subdir for sharing container images
+	if err := createDirIfNotExists(clusterPath + "/images"); err != nil {
+		log.Fatalf("ERROR: couldn't create cluster sub-directory [%s] -> %+v", clusterPath+"/images", err)
+	}
 }
 
 // deleteClusterDir contrary to createClusterDir, this deletes the cluster directory under $HOME/.config/k3d/<cluster_name>

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -365,5 +365,11 @@ func Shell(c *cli.Context) error {
 
 // ImportImage saves an image locally and imports it into the k3d containers
 func ImportImage(c *cli.Context) error {
-	return importImage(c.String("name"), c.String("image"))
+	images := make([]string, 0)
+	if strings.Contains(c.Args().First(), ",") {
+		images = append(images, strings.Split(c.Args().First(), ",")...)
+	} else {
+		images = append(images, c.Args()...)
+	}
+	return importImage(c.String("name"), images)
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -385,5 +385,5 @@ func ImportImage(c *cli.Context) error {
 	} else {
 		images = append(images, c.Args()...)
 	}
-	return importImage(c.String("name"), images)
+	return importImage(c.String("name"), images, c.Bool("no-remove"))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -100,7 +100,7 @@ func CreateCluster(c *cli.Context) error {
 	if c.IsSet("port") {
 		log.Println("INFO: As of v2.0.0 --port will be used for arbitrary port mapping. Please use --api-port/-a instead for configuring the Api Port")
 	}
-	apiPort, err := parseApiPort(c.String("api-port"))
+	apiPort, err := parseAPIPort(c.String("api-port"))
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func CreateCluster(c *cli.Context) error {
 	if apiPort.Host == "" {
 		apiPort.Host, err = getDockerMachineIp()
 		// IP address is the same as the host
-		apiPort.HostIp = apiPort.Host
+		apiPort.HostIP = apiPort.Host
 		// In case of error, Log a warning message, and continue on. Since it more likely caused by a miss configured
 		// DOCKER_MACHINE_NAME environment variable.
 		if err != nil {
@@ -137,7 +137,7 @@ func CreateCluster(c *cli.Context) error {
 
 	clusterSpec := &ClusterSpec{
 		AgentArgs:         []string{},
-		ApiPort:           *apiPort,
+		APIPort:           *apiPort,
 		AutoRestart:       c.Bool("auto-restart"),
 		ClusterName:       c.String("name"),
 		Env:               env,
@@ -151,6 +151,10 @@ func CreateCluster(c *cli.Context) error {
 
 	// create the server
 	log.Printf("Creating cluster [%s]", c.String("name"))
+
+	// create the directory where we will put the kubeconfig file by default (when running `k3d get-config`)
+	createClusterDir(c.String("name"))
+
 	dockerID, err := createServer(clusterSpec)
 	if err != nil {
 		deleteCluster()
@@ -191,10 +195,6 @@ func CreateCluster(c *cli.Context) error {
 
 		time.Sleep(1 * time.Second)
 	}
-
-	// create the directory where we will put the kubeconfig file by default (when running `k3d get-config`)
-	// TODO: this can probably be moved to `k3d get-config` or be removed in a different approach
-	createClusterDir(c.String("name"))
 
 	// spin up the worker nodes
 	// TODO: do this concurrently in different goroutines
@@ -361,4 +361,9 @@ func GetKubeConfig(c *cli.Context) error {
 // Shell starts a new subshell with the KUBECONFIG pointing to the selected cluster
 func Shell(c *cli.Context) error {
 	return subShell(c.String("name"), c.String("shell"), c.String("command"))
+}
+
+// ImportImage saves an image locally and imports it into the k3d containers
+func ImportImage(c *cli.Context) error {
+	return importImage(c.String("name"), c.String("image"))
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -123,13 +123,6 @@ func createServer(spec *ClusterSpec) (string, error) {
 		hostConfig.Binds = spec.Volumes
 	}
 
-	// we need to mount the clusterDir subdirectory `clusterDir/images` to enable importing images without the need for `docker cp`
-	clusterDir, err := getClusterDir(spec.ClusterName)
-	if err != nil {
-		return "", fmt.Errorf("ERROR: couldn't get cluster dir for mounting\n%+v", err)
-	}
-	hostConfig.Binds = append(hostConfig.Binds, fmt.Sprintf("%s:/images", clusterDir+"/images"))
-
 	networkingConfig := &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
 			k3dNetworkName(spec.ClusterName): {
@@ -198,13 +191,6 @@ func createWorker(spec *ClusterSpec, postfix int) (string, error) {
 	if len(spec.Volumes) > 0 && spec.Volumes[0] != "" {
 		hostConfig.Binds = spec.Volumes
 	}
-
-	// we need to mount the clusterDir subdirectory `clusterDir/images` to enable importing images without the need for `docker cp`
-	clusterDir, err := getClusterDir(spec.ClusterName)
-	if err != nil {
-		return "", fmt.Errorf("ERROR: couldn't get cluster dir for mounting\n%+v", err)
-	}
-	hostConfig.Binds = append(hostConfig.Binds, fmt.Sprintf("%s:/images", clusterDir+"/images"))
 
 	networkingConfig := &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{

--- a/cli/container.go
+++ b/cli/container.go
@@ -230,7 +230,7 @@ func removeContainer(ID string) error {
 	}
 
 	if err := docker.ContainerRemove(ctx, ID, options); err != nil {
-		return fmt.Errorf("FAILURE: couldn't delete container [%s] -> %+v", ID, err)
+		return fmt.Errorf("ERROR: couldn't delete container [%s] -> %+v", ID, err)
 	}
 	return nil
 }

--- a/cli/image.go
+++ b/cli/image.go
@@ -1,0 +1,131 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+)
+
+const imageBasePathRemote = "/images/"
+
+func importImage(clusterName, image string) error {
+	// get a docker client
+	ctx := context.Background()
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't create docker client\n%+v", err)
+	}
+
+	// get cluster directory to temporarily save the image tarball there
+	imageBasePathLocal, err := getClusterDir(clusterName)
+	imageBasePathLocal = imageBasePathLocal + "/images/"
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't get cluster directory for cluster [%s]\n%+v", clusterName, err)
+	}
+
+	// TODO: extend to enable importing a list of images
+	imageList := []string{image}
+
+	//*** first, save the images using the local docker daemon
+	log.Printf("INFO: Saving image [%s] from local docker daemon...", image)
+	imageReader, err := docker.ImageSave(ctx, imageList)
+	if err != nil {
+		return fmt.Errorf("ERROR: failed to save image [%s] locally\n%+v", image, err)
+	}
+
+	// create tarball
+	imageTarName := strings.ReplaceAll(strings.ReplaceAll(image, ":", "_"), "/", "_") + ".tar"
+	imageTar, err := os.Create(imageBasePathLocal + imageTarName)
+	if err != nil {
+		return err
+	}
+	defer imageTar.Close()
+
+	_, err = io.Copy(imageTar, imageReader)
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't save image [%s] to file [%s]\n%+v", image, imageTar.Name(), err)
+	}
+
+	// TODO: get correct container ID by cluster name
+	clusters, err := getClusters(false, clusterName)
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't get cluster by name [%s]\n%+v", clusterName, err)
+	}
+	containerList := []types.Container{clusters[clusterName].server}
+	containerList = append(containerList, clusters[clusterName].workers...)
+
+	// *** second, import the images using ctr in the k3d nodes
+
+	// create exec configuration
+	cmd := []string{"ctr", "image", "import", imageBasePathRemote + imageTarName}
+	execConfig := types.ExecConfig{
+		AttachStderr: true,
+		AttachStdout: true,
+		Cmd:          cmd,
+		Tty:          true,
+		Detach:       true,
+	}
+
+	execAttachConfig := types.ExecConfig{
+		Tty: true,
+	}
+
+	execStartConfig := types.ExecStartCheck{
+		Tty: true,
+	}
+
+	// import in each node separately
+	// TODO: create a shared image cache volume, so we don't need to import it separately
+	for _, container := range containerList {
+
+		containerName := container.Names[0][1:] // trimming the leading "/" from name
+		log.Printf("INFO: Importing image [%s] in container [%s]", image, containerName)
+
+		// create exec configuration
+		execResponse, err := docker.ContainerExecCreate(ctx, container.ID, execConfig)
+		if err != nil {
+			return fmt.Errorf("ERROR: Failed to create exec command for container [%s]\n%+v", containerName, err)
+		}
+
+		// attach to exec process in container
+		containerConnection, err := docker.ContainerExecAttach(ctx, execResponse.ID, execAttachConfig)
+		if err != nil {
+			return fmt.Errorf("ERROR: couldn't attach to container [%s]\n%+v", containerName, err)
+		}
+		defer containerConnection.Close()
+
+		// start exec
+		err = docker.ContainerExecStart(ctx, execResponse.ID, execStartConfig)
+		if err != nil {
+			return fmt.Errorf("ERROR: couldn't execute command in container [%s]\n%+v", containerName, err)
+		}
+
+		// get output from container
+		content, err := ioutil.ReadAll(containerConnection.Reader)
+		if err != nil {
+			return fmt.Errorf("ERROR: couldn't read output from container [%s]\n%+v", containerName, err)
+		}
+
+		// example output "unpacking image........ ...done"
+		if !strings.Contains(string(content), "done") {
+			return fmt.Errorf("ERROR: seems like something went wrong using `ctr image import` in container [%s]. Full output below:\n%s", containerName, string(content))
+		}
+	}
+
+	log.Printf("INFO: Successfully imported image [%s] in all nodes of cluster [%s]", image, clusterName)
+
+	log.Println("INFO: Cleaning up tarball...")
+	if err := os.Remove(imageBasePathLocal + imageTarName); err != nil {
+		return fmt.Errorf("ERROR: Couldn't remove tarball [%s]\n%+v", imageBasePathLocal+imageTarName, err)
+	}
+	log.Println("INFO: ...Done")
+
+	return nil
+}

--- a/cli/image.go
+++ b/cli/image.go
@@ -29,7 +29,6 @@ func importImage(clusterName string, images []string) error {
 	if err != nil {
 		return fmt.Errorf("ERROR: couldn't get image volume for cluster [%s]\n%+v", clusterName, err)
 	}
-	imageBasePathLocal := imageVolume.Mountpoint + "/"
 
 	//*** first, save the images using the local docker daemon
 	log.Printf("INFO: Saving images [%s] from local docker daemon...", images)

--- a/cli/image.go
+++ b/cli/image.go
@@ -25,11 +25,11 @@ func importImage(clusterName string, images []string) error {
 	}
 
 	// get cluster directory to temporarily save the image tarball there
-	imageBasePathLocal, err := getClusterDir(clusterName)
-	imageBasePathLocal = imageBasePathLocal + "/images/"
+	imageVolume, err := getImageVolume(clusterName)
 	if err != nil {
-		return fmt.Errorf("ERROR: couldn't get cluster directory for cluster [%s]\n%+v", clusterName, err)
+		return fmt.Errorf("ERROR: couldn't get image volume for cluster [%s]\n%+v", clusterName, err)
 	}
+	imageBasePathLocal := imageVolume.Mountpoint + "/"
 
 	//*** first, save the images using the local docker daemon
 	log.Printf("INFO: Saving images [%s] from local docker daemon...", images)

--- a/cli/util.go
+++ b/cli/util.go
@@ -11,7 +11,7 @@ import (
 
 type apiPort struct {
 	Host   string
-	HostIp string
+	HostIP string
 	Port   string
 }
 
@@ -90,7 +90,7 @@ func ValidateHostname(name string) error {
 	return nil
 }
 
-func parseApiPort(portSpec string) (*apiPort, error) {
+func parseAPIPort(portSpec string) (*apiPort, error) {
 	var port *apiPort
 	split := strings.Split(portSpec, ":")
 	if len(split) > 2 {
@@ -105,7 +105,7 @@ func parseApiPort(portSpec string) (*apiPort, error) {
 		if err != nil {
 			return nil, err
 		}
-		port = &apiPort{Host: split[0], HostIp: addrs[0], Port: split[1]}
+		port = &apiPort{Host: split[0], HostIP: addrs[0], Port: split[1]}
 	}
 
 	// Verify 'port' is an integer and within port ranges

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -1,0 +1,92 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+)
+
+// createImageVolume will create a new docker volume used for storing image tarballs that can be loaded into the clusters
+func createImageVolume(clusterName string) (types.Volume, error) {
+
+	var vol types.Volume
+
+	ctx := context.Background()
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		return vol, fmt.Errorf("ERROR: couldn't create docker client\n%+v", err)
+	}
+
+	volName := fmt.Sprintf("k3d-%s-images", clusterName)
+
+	volumeCreateOptions := volume.VolumesCreateBody{
+		Name: volName,
+		Labels: map[string]string{
+			"app":     "k3d",
+			"cluster": clusterName,
+		},
+		Driver:     "local", //TODO: allow setting driver + opts
+		DriverOpts: map[string]string{},
+	}
+	vol, err = docker.VolumeCreate(ctx, volumeCreateOptions)
+	if err != nil {
+		return vol, fmt.Errorf("ERROR: failed to create image volume [%s] for cluster [%s]\n%+v", volName, clusterName, err)
+	}
+
+	return vol, nil
+}
+
+// deleteImageVolume will delete the volume we created for sharing images with this cluster
+func deleteImageVolume(clusterName string) error {
+
+	ctx := context.Background()
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		return fmt.Errorf("ERROR: couldn't create docker client\n%+v", err)
+	}
+
+	volName := fmt.Sprintf("k3d-%s-images", clusterName)
+
+	if err = docker.VolumeRemove(ctx, volName, true); err != nil {
+		return fmt.Errorf("ERROR: couldn't remove volume [%s] for cluster [%s]\n%+v", volName, clusterName, err)
+	}
+
+	return nil
+}
+
+// getImageVolume returns the docker volume object representing the imagevolume for the cluster
+func getImageVolume(clusterName string) (types.Volume, error) {
+	var vol types.Volume
+	volName := fmt.Sprintf("k3d-%s-images", clusterName)
+
+	ctx := context.Background()
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		return vol, fmt.Errorf("ERROR: couldn't create docker client\n%+v", err)
+	}
+
+	filters := filters.NewArgs()
+	filters.Add("label", "app=k3d")
+	filters.Add("label", fmt.Sprintf("cluster=%s", clusterName))
+	volumeList, err := docker.VolumeList(ctx, filters)
+	if err != nil {
+		return vol, fmt.Errorf("ERROR: couldn't get volumes for cluster [%s]\n%+v ", clusterName, err)
+	}
+	volFound := false
+	for _, volume := range volumeList.Volumes {
+		if volume.Name == volName {
+			vol = *volume
+			volFound = true
+			break
+		}
+	}
+	if !volFound {
+		return vol, fmt.Errorf("ERROR: didn't find volume [%s] in list of volumes returned for cluster [%s]", volName, clusterName)
+	}
+
+	return vol, nil
+}

--- a/main.go
+++ b/main.go
@@ -225,6 +225,10 @@ func main() {
 					Value: defaultK3sClusterName,
 					Usage: "Name of the cluster",
 				},
+				cli.BoolFlag{
+					Name:  "no-remove, no-rm, keep, k",
+					Usage: "Disable automatic removal of the tarball",
+				},
 			},
 			Action: run.ImportImage,
 		},

--- a/main.go
+++ b/main.go
@@ -216,17 +216,14 @@ func main() {
 		},
 		{
 			// get-kubeconfig grabs the kubeconfig from the cluster and prints the path to it
-			Name:  "import-image",
-			Usage: "Import a container image from your local docker daemon into the cluster",
+			Name:    "import-images",
+			Aliases: []string{"i"},
+			Usage:   "Import a comma- or space-separated list of container images from your local docker daemon into the cluster",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "name, n",
+					Name:  "name, n, cluster, c",
 					Value: defaultK3sClusterName,
 					Usage: "Name of the cluster",
-				},
-				cli.StringFlag{
-					Name:  "image, i",
-					Usage: "Name of the image that you want to import, e.g. `nginx:local`",
 				},
 			},
 			Action: run.ImportImage,

--- a/main.go
+++ b/main.go
@@ -214,6 +214,23 @@ func main() {
 			},
 			Action: run.GetKubeConfig,
 		},
+		{
+			// get-kubeconfig grabs the kubeconfig from the cluster and prints the path to it
+			Name:  "import-image",
+			Usage: "Import a container image from your local docker daemon into the cluster",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "name, n",
+					Value: defaultK3sClusterName,
+					Usage: "Name of the cluster",
+				},
+				cli.StringFlag{
+					Name:  "image, i",
+					Usage: "Name of the image that you want to import, e.g. `nginx:local`",
+				},
+			},
+			Action: run.ImportImage,
+		},
 	}
 
 	// Global flags

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,6 +8,7 @@ github.com/docker/docker/api/types
 github.com/docker/docker/api/types/container
 github.com/docker/docker/api/types/filters
 github.com/docker/docker/api/types/network
+github.com/docker/docker/api/types/volume
 github.com/docker/docker/client
 github.com/docker/docker/api/types/mount
 github.com/docker/docker/api/types/registry
@@ -18,7 +19,6 @@ github.com/docker/docker/api/types/versions
 github.com/docker/docker/api/types/events
 github.com/docker/docker/api/types/reference
 github.com/docker/docker/api/types/time
-github.com/docker/docker/api/types/volume
 github.com/docker/docker/pkg/tlsconfig
 # github.com/docker/go-connections v0.4.0
 github.com/docker/go-connections/nat


### PR DESCRIPTION
## Context

`k3d import-images` to import docker images from the used docker daemon into containerd inside the k3d nodes.
This is a new version of PR #83 which makes use of a named volume and an additional `k3d-tools` container.

## How it works

1. upon k3d create, a named volume for storing images will be created and mounted on /images in all nodes (**NOTE**: this requires at least `--image rancher/k3s:v0.7.0-rc2` because of `ctr`)
2. user has nginx:local and redis:v2 cached locally after issuing docker build and wants to have them available to the k3d nodes (without having to push to a registry)
3. user issues `$ k3d import-images --cluster test-cluster nginx:local redis:v2` 
4. a helper container (currently iwilltry42/k3d-tools:v0.0.1) will be spawned, mounting the same volume as the nodes and `/var/run/docker.sock` to have access to the docker daemon/API
5. the helper container will internally run a `docker save nginx:local redis:v2 -o /images/images.tar` (API variant)
6. the `/iamges/images.tar` is then available to the k3d nodes
7. k3d will exec a `ctr image import /images/images.tar` in every k3d node to import the images into each node's containerd image cache
8. the helper container will be removed again (and the tarball if wanted)

## Explanation
I chose this approach, since I had much trouble with the other approach (saving the stream to a tarball on the fly) and because I think that we can save bandwidth and avoid possible network latency by working directly on the docker host (which might be remote) instead of saving from docker host to local host and copy the tarball back.
The drawback is, that we'll have to maintain the additional docker image as well, though it's really small.


## Possible TODOs

- [x] add either `--rm` or `--no-rm` flag to enable/disable automatic removal of the tarball
  - UPDATE 11.07.2019: added `--no-remove, --no-rm, --keep, -k` flag to disable automatic removal
- [ ] add `--all-cached` (or similar) flag to directly import all tarballs that are already in the `/images` directory
- [ ] add `--from-tar` flag to import from a tarball that you have saved locally (branching before we create the helper container)
- [ ] rollback (i.e. delete helper container) in any case of error

FYI @andyz-dev 