### PR TITLE
Expose `--agent-arg` like `--server-arg`

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -105,7 +105,7 @@ func CreateCluster(c *cli.Context) error {
 		return err
 	}
 
-	k3AgentArgs := make([]string, 0)
+	k3AgentArgs := []string{}
 	k3sServerArgs := []string{"--https-listen-port", apiPort.Port}
 
 	// When the 'host' is not provided by --api-port, try to fill it using Docker Machine's IP address.

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -105,6 +105,7 @@ func CreateCluster(c *cli.Context) error {
 		return err
 	}
 
+	k3AgentArgs := make([]string, 0)
 	k3sServerArgs := []string{"--https-listen-port", apiPort.Port}
 
 	// When the 'host' is not provided by --api-port, try to fill it using Docker Machine's IP address.
@@ -129,6 +130,10 @@ func CreateCluster(c *cli.Context) error {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
+	if c.IsSet("agent-arg") {
+		k3AgentArgs = append(k3AgentArgs, c.StringSlice("agent-arg")...)
+	}
+
 	// new port map
 	portmap, err := mapNodesToPortSpecs(c.StringSlice("publish"), GetAllContainerNames(c.String("name"), defaultServerCount, c.Int("workers")))
 	if err != nil {
@@ -145,7 +150,7 @@ func CreateCluster(c *cli.Context) error {
 	volumes = append(volumes, fmt.Sprintf("%s:/images", imageVolume.Name))
 
 	clusterSpec := &ClusterSpec{
-		AgentArgs:         []string{},
+		AgentArgs:         k3AgentArgs,
 		APIPort:           *apiPort,
 		AutoRestart:       c.Bool("auto-restart"),
 		ClusterName:       c.String("name"),

--- a/cli/container.go
+++ b/cli/container.go
@@ -204,6 +204,7 @@ func createWorker(spec *ClusterSpec, postfix int) (string, error) {
 		Hostname:     containerName,
 		Image:        spec.Image,
 		Env:          env,
+		Cmd:          append([]string{"agent"}, spec.AgentArgs...),
 		Labels:       containerLabels,
 		ExposedPorts: workerPublishedPorts.ExposedPorts,
 	}

--- a/main.go
+++ b/main.go
@@ -117,6 +117,10 @@ func main() {
 					Usage: "Pass an additional argument to k3s server (new flag per argument)",
 				},
 				cli.StringSliceFlag{
+					Name:  "agent-arg",
+					Usage: "Pass an additional argument to k3s agent (new flag per argument)",
+				},
+				cli.StringSliceFlag{
 					Name:  "env, e",
 					Usage: "Pass an additional environment variable (new flag per variable)",
 				},


### PR DESCRIPTION
Expose `--agent-arg` flag and forward those to k3s like we do for `--server-arg`.

There is an agent arg in the cluster spec, but it is not forwarded to the container config when starting the container. This change exposes the agent arg so that options passed to kubernetes components in the master container can also be passed to workers.

Fixes #86 