### PR TITLE
Build-fix for MacOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,26 +4,29 @@ go 1.12
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/Microsoft/go-winio v0.4.12
 	github.com/containerd/containerd v1.2.7 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v0.7.3-0.20190723064612-a9dc697fd2a5
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/go-units v0.3.3 // indirect
-	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/docker/go-units v0.3.3
+	github.com/gogo/protobuf v1.2.1
 	github.com/gorilla/mux v1.7.3 // indirect
-	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mattn/go-runewidth v0.0.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/olekukonko/tablewriter v0.0.1
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.1
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/urfave/cli v1.20.0
-	golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b // indirect
+	golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b
+	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+replace github.com/docker/docker v1.13.1 => github.com/docker/docker v0.7.3-0.20190723064612-a9dc697fd2a5

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,10 +3,10 @@ github.com/Microsoft/go-winio
 # github.com/containerd/containerd v1.2.7
 github.com/containerd/containerd/errdefs
 # github.com/docker/distribution v2.7.1+incompatible
+github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
-github.com/docker/distribution/digestset
-# github.com/docker/docker v0.7.3-0.20190723064612-a9dc697fd2a5
+# github.com/docker/docker v1.13.1 => github.com/docker/docker v0.7.3-0.20190723064612-a9dc697fd2a5
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/container
 github.com/docker/docker/api/types/filters
@@ -19,12 +19,12 @@ github.com/docker/docker/api/types/swarm
 github.com/docker/docker/api/types/blkiodev
 github.com/docker/docker/api/types/strslice
 github.com/docker/docker/api/types/versions
-github.com/docker/docker/errdefs
+github.com/docker/docker/api/types/swarm/runtime
 github.com/docker/docker/api
 github.com/docker/docker/api/types/events
 github.com/docker/docker/api/types/image
 github.com/docker/docker/api/types/time
-github.com/docker/docker/api/types/swarm/runtime
+github.com/docker/docker/errdefs
 # github.com/docker/go-connections v0.4.0
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
@@ -59,11 +59,13 @@ github.com/sirupsen/logrus
 # github.com/urfave/cli v1.20.0
 github.com/urfave/cli
 # golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b
+golang.org/x/net/context
+golang.org/x/net/context/ctxhttp
 golang.org/x/net/proxy
 golang.org/x/net/internal/socks
 # golang.org/x/sys v0.0.0-20190422165155-953cdadca894
-golang.org/x/sys/unix
 golang.org/x/sys/windows
+golang.org/x/sys/unix
 # google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.22.0


### PR DESCRIPTION
Tip of the k3d master build fails on MacOS with out the PR change.

When compiling, I go the following error:

go build -i  -tags '' -ldflags '-w -s -X github.com/rancher/k3d/version.Version=v1.3.1-3-g460ff827f484 -X github.com/rancher/k3d/version.K3sVersion=v0.8.0' -o '/Users/azhou/projs/k3d/bin/k3d'
cli/cluster.go:101:17: undefined: client.NewClientWithOpts
cli/cluster.go:101:42: undefined: client.FromEnv
cli/cluster.go:101:58: undefined: client.WithAPIVersionNegotiation
cli/cluster.go:256:17: undefined: client.NewClientWithOpts
cli/cluster.go:256:42: undefined: client.FromEnv
cli/cluster.go:256:58: undefined: client.WithAPIVersionNegotiation
cli/commands.go:32:17: undefined: client.NewClientWithOpts
cli/commands.go:32:42: undefined: client.FromEnv
cli/commands.go:32:58: undefined: client.WithAPIVersionNegotiation
cli/commands.go:179:17: undefined: client.NewClientWithOpts
cli/commands.go:179:17: too many errors

$ go version
go version go1.12.4 darwin/amd64

For some reason, the 'make build' also modifies the go.mod. I was
not able to pin the version docker library without adding the replace line
at the bottom of go.mod file.

Have not tested building on the other platforms. Any feedback will be
greatly appreciated.