### PR TITLE
Allow passing `TAG` to install a specific release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You have several options there:
 - use the install script to grab the latest release:
   - wget: `wget -q -O - https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash`
   - curl: `curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash`
+- use the install script to grab a specific release (via `TAG` environment variable):
+  - wget: `wget -q -O - https://raw.githubusercontent.com/rancher/k3d/master/install.sh | TAG=v1.3.1 bash`
+  - curl: `curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | TAG=v1.3.1 bash`
+
 - Grab a release from the [release tab](https://github.com/rancher/k3d/releases) and install it yourself.
 - Via go: `go install github.com/rancher/k3d` (**Note**: this will give you unreleased/bleeding-edge changes)
 

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,11 @@ checkK3dInstalledVersion() {
   fi
 }
 
+# checkTagProvided checks whether TAG has provided as an environment variable so we can skip checkLatestVersion.
+checkTagProvided() {
+  [[ ! -z "$TAG" ]]
+}
+
 # checkLatestVersion grabs the latest version string from the releases
 checkLatestVersion() {
   local latest_release_url="$REPO_URL/releases/latest"
@@ -178,7 +183,7 @@ set +u
 initArch
 initOS
 verifySupported
-checkLatestVersion
+checkTagProvided || checkLatestVersion
 if ! checkK3dInstalledVersion; then
   downloadFile
   installFile


### PR DESCRIPTION
Hey :wave:,

this PR enables the install script to grab a specific release rather than "the latest".

Use case: Predictable feature set by relying on a specific version. 

Feedback is much appreciated :purple_heart:  

Kind regards,
  Peter