### PR TITLE
Add docker.io registry to a config.toml.tmpl

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -124,6 +124,8 @@ sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
 
 # Added section: additional registries and the endpoints
 [plugins.cri.registry.mirrors]
+  [plugins.cri.registry.mirrors."docker.io"]
+    endpoint = ["https://registry-1.docker.io"
   [plugins.cri.registry.mirrors."<b>registry.local:5000</b>"]
     endpoint = ["http://<b>registry.local:5000</b>"]
 </pre>


### PR DESCRIPTION
I've added registry endpoint of the docker.io that  necessary to start k3s cluster correctly.