### PR TITLE
[Feature] add --network flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _dist/
 
 # Editors
 .vscode/
+.idea/

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -168,6 +168,15 @@ func CreateCluster(c *cli.Context) error {
 		Volumes:           volumesSpec,
 	}
 
+	// deal with --network option, if specified add it into clusterSpec
+	networkName := c.String("network")
+	if networkName != "" {
+		if clusterSpec.Network, err = createJoinableNetwork(networkName); err != nil {
+			// just emit warning if any error occurred during initialization of the bridge network
+			log.Warningf("Failed to create bridge network %s: %s", c.String("network"), err)
+		}
+	}
+
 	// create the server
 	log.Printf("Creating cluster [%s]", c.String("name"))
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -83,12 +83,18 @@ func CreateCluster(c *cli.Context) error {
 		image = fmt.Sprintf("%s/%s", defaultRegistry, image)
 	}
 
-	// create cluster network
-	networkID, err := createClusterNetwork(c.String("name"))
-	if err != nil {
-		return err
+	// we initiate this variable here to check if --network option is provided
+	// but we will use it later if it's set
+	networkName := c.String("network")
+
+	if networkName == "" {
+		// create cluster network, only if --network option is not provided
+		networkID, err := createClusterNetwork(c.String("name"))
+		if err != nil {
+			return err
+		}
+		log.Printf("Created cluster network with ID %s", networkID)
 	}
-	log.Printf("Created cluster network with ID %s", networkID)
 
 	// environment variables
 	env := []string{"K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml"}
@@ -173,7 +179,6 @@ func CreateCluster(c *cli.Context) error {
 
 	// deal with --network option, if specified add it into clusterSpec
 	// will throw error if the network doesn't exist
-	networkName := c.String("network")
 	if networkName != "" {
 		if clusterSpec.Network, err = checkIfNetworkExists(networkName); err != nil {
 			log.Fatalf("Failure on --network usage: %s", err)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -169,11 +169,11 @@ func CreateCluster(c *cli.Context) error {
 	}
 
 	// deal with --network option, if specified add it into clusterSpec
+	// will throw error if the network doesn't exist
 	networkName := c.String("network")
 	if networkName != "" {
-		if clusterSpec.Network, err = createJoinableNetwork(networkName); err != nil {
-			// just emit warning if any error occurred during initialization of the bridge network
-			log.Warningf("Failed to create bridge network %s: %s", c.String("network"), err)
+		if clusterSpec.Network, err = checkIfNetworkExists(networkName); err != nil {
+			log.Fatalf("Failure on --network usage: %s", err)
 		}
 	}
 

--- a/cli/image.go
+++ b/cli/image.go
@@ -58,7 +58,7 @@ func importImage(clusterName string, images []string, noRemove bool) error {
 		},
 	}
 
-	toolsContainerID, err := startContainer(&containerConfig, &hostConfig, &network.NetworkingConfig{}, toolsContainerName)
+	toolsContainerID, err := startContainer(&containerConfig, &hostConfig, &network.NetworkingConfig{}, toolsContainerName, nil)
 	if err != nil {
 		return err
 	}
@@ -149,6 +149,7 @@ func importImage(clusterName string, images []string, noRemove bool) error {
 		if err != nil {
 			return fmt.Errorf(" Couldn't attach to container [%s]\n%+v", containerName, err)
 		}
+		// TODO: Evaluate this potential issue: Possible resource leak, defer in for loop
 		defer containerConnection.Close()
 
 		// start exec

--- a/cli/network.go
+++ b/cli/network.go
@@ -14,6 +14,11 @@ func k3dNetworkName(clusterName string) string {
 	return fmt.Sprintf("k3d-%s", clusterName)
 }
 
+
+func createJoinableNetwork(clusterName string, networkName string) error {
+	return nil
+}
+
 // createClusterNetwork creates a docker network for a cluster that will be used
 // to let the server and worker containers communicate with each other easily.
 func createClusterNetwork(clusterName string) (string, error) {

--- a/main.go
+++ b/main.go
@@ -134,6 +134,10 @@ func main() {
 					Name:  "auto-restart",
 					Usage: "Set docker's --restart=unless-stopped flag on the containers",
 				},
+				cli.StringFlag{
+					Name:  "network",
+					Usage: "Connect the cluster to specified network, if <network> doesn't exist it will be created. Note that the created network will be prefixed with k3d-",
+				},
 			},
 			Action: run.CreateCluster,
 		},

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "network",
-					Usage: "Connect the cluster to specified network, if <network> doesn't exist it will be created. Note that the created network will be prefixed with k3d-",
+					Usage: "Connect the cluster to specified network, make sure the network you want to connect with exists",
 				},
 			},
 			Action: run.CreateCluster,


### PR DESCRIPTION
addresses #111 

. I enabled the `--network` option on create command which take a string value
. created new struct `networkConfig` which include ID of the network and the EndpointSettings builder coupled with it, the builder take containerName as parameter
. As it's not allowed to create container with multiple network, I settled the connection to the bridge network just before starting the container assuming that `networkConfig` is defined

That's all done so far, probably there is some point to improve, any feedbacks would be appreciated