### PR TITLE
Only ignore get-kubeconfig error when !all

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -379,6 +379,9 @@ func GetKubeConfig(c *cli.Context) error {
 	for _, cluster := range clusters {
 		kubeConfigPath, err := getKubeConfig(cluster.name)
 		if err != nil {
+			if !c.Bool("all") {
+				return err
+			}
 			log.Println(err)
 			continue
 		}


### PR DESCRIPTION
If you are writing a script to launch k3s clusters checking the exit
code of `get-kubeconfig` is an easy way to tell if the kubeconfig is
available for use.