### PR TITLE
Launch containers with init

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -112,6 +112,7 @@ func createServer(spec *ClusterSpec) (string, error) {
 	hostConfig := &container.HostConfig{
 		PortBindings: serverPublishedPorts.PortBindings,
 		Privileged:   true,
+		Init:         &[]bool{true}[0],
 	}
 
 	if spec.AutoRestart {


### PR DESCRIPTION
k3s is not a child subreaper so running k3s as PID 1 will result
in zombie processes.  Using `docker run --init` works around this
issue.