### PR TITLE
[Docs] Using rancher to administer the cluster

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -257,7 +257,6 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# This role binding allows "jane" to read pods in the "default" namespace.
 kind: ClusterRoleBinding
 metadata:
   name: rancher

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -228,3 +228,87 @@ cleanup() {
 setup
 #cleanup
 ```
+## Rancher for administering the cluster
+
+Install rancher in to the same cluser for administering the cluster.
+
+```
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rancher
+  namespace: cattle-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: rancher
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# This role binding allows "jane" to read pods in the "default" namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: rancher
+subjects:
+- kind: ServiceAccount
+  name: rancher
+  namespace: cattle-system
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole #this must be Role or ClusterRole
+  name: rancher
+  apiGroup: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rancher
+  namespace: cattle-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rancher
+  template:
+    metadata:
+      labels:
+        app: rancher
+    spec:
+      serviceAccountName: rancher
+      containers:
+      - name: name
+        image: rancher/rancher
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        ports:
+        - containerPort: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher
+  namespace: cattle-system
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: rancher
+```
+and then
+`kubectl apply -f rancher.yaml`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -304,7 +304,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 443
+  - port: 8443
     targetPort: 443
   selector:
     app: rancher


### PR DESCRIPTION
As of now, k3d is restricted to local kubectl tooling, or have to have a vm, with static ip which is routable from the api server to manage k3d cluster via rancher.
This yaml will create proper permissions (cluster-admin) and allow rancher to take over the cluster