### PR TITLE
Fix kubeconfig not pointing to correct host when using docker-machine

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -161,6 +161,7 @@ func createKubeConfigFile(cluster string) error {
 	if apiHost != "" {
 		s := string(trimBytes)
 		s = strings.Replace(s, "localhost", apiHost, 1)
+		s = strings.Replace(s, "127.0.0.1", apiHost, 1)
 		trimBytes = []byte(s)
 	}
 	_, err = kubeconfigfile.Write(trimBytes)


### PR DESCRIPTION
The kubeconfig generated by `docker.io/rancher/k3s:v0.10.2` or earlier sets the `cluster.server` address to `127.0.0.1`. Previously this seems to have been `localhost`. And we only replace `localhost` with the correct address for our local kubeconfig.

The error I encountered:
```
$ k3d --version
k3d version v1.3.4
$ docker-machine --version
docker-machine version 0.16.1, build cce350d7
$ docker --version
Docker version 19.03.1, build 74b1e89
$ k3d create
INFO[0000] Created cluster network with ID 649d6f34b84a4df16d2524f0ea0ce69cd4f964a79ae56e2a07bb1ee11d1fce50
INFO[0001] Add TLS SAN for 192.168.99.100
INFO[0001] Created docker volume  k3d-k3s-default-images
INFO[0001] Creating cluster [k3s-default]
INFO[0001] Creating server using docker.io/rancher/k3s:v0.10.2...
INFO[0001] Pulling image docker.io/rancher/k3s:v0.10.2...
INFO[0018] SUCCESS: created cluster [k3s-default]
INFO[0018] You can now use the cluster with:

export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
kubectl cluster-info
$ export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
$ kubectl cluster-info

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
The connection to the server 127.0.0.1:6443 was refused - did you specify the right host or port?
```