### PR TITLE
[Feature] add ability to set docker labels on worker nodes

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -104,6 +104,14 @@ func CreateCluster(c *cli.Context) error {
 	env = append(env, fmt.Sprintf("K3S_CLUSTER_SECRET=%s", GenerateRandomString(20)))
 
 	/*
+	 * --label, -l
+	 * Docker container labels that will be added to the k3d node containers
+	 */
+	// labels
+	labels := []string{}
+	labels = append(labels, c.StringSlice("label")...)
+
+	/*
 	 * Arguments passed on to the k3s server and agent, will be filled later
 	 */
 	k3AgentArgs := []string{}
@@ -204,6 +212,7 @@ func CreateCluster(c *cli.Context) error {
 		AutoRestart:       c.Bool("auto-restart"),
 		ClusterName:       c.String("name"),
 		Env:               env,
+		Labels:            labels,
 		Image:             image,
 		NodeToPortSpecMap: portmap,
 		PortAutoOffset:    c.Int("port-auto-offset"),
@@ -481,6 +490,7 @@ func AddNode(c *cli.Context) error {
 		AutoRestart:       false,
 		ClusterName:       clusterName,
 		Env:               nil,
+		Labels:            nil,
 		Image:             "",
 		NodeToPortSpecMap: nil,
 		PortAutoOffset:    0,
@@ -558,6 +568,13 @@ func AddNode(c *cli.Context) error {
 		}
 		return nil
 	}
+
+	/* (0.6)
+	 * --label, -l <key1=val1>
+	 * Docker container labels that will be added to the k3d node containers
+	 */
+	clusterSpec.Labels = []string{}
+	clusterSpec.Labels = append(clusterSpec.Labels, c.StringSlice("label")...)
 
 	/*
 	 * (1) Check cluster

--- a/cli/container.go
+++ b/cli/container.go
@@ -142,6 +142,16 @@ func createWorker(spec *ClusterSpec, postfix int) (string, error) {
 	containerLabels["created"] = time.Now().Format("2006-01-02 15:04:05")
 	containerLabels["cluster"] = spec.ClusterName
 
+	for _, label := range spec.Labels {
+		labelSlice := strings.SplitN(label, "=", 2)
+
+		if len(labelSlice) > 1 {
+			containerLabels[labelSlice[0]] = labelSlice[1]
+		} else {
+			containerLabels[labelSlice[0]] = ""
+		}
+	}
+
 	containerName := GetContainerName("worker", spec.ClusterName, postfix)
 	env := spec.Env
 

--- a/cli/label.go
+++ b/cli/label.go
@@ -1,0 +1,121 @@
+package run
+
+import (
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// mapNodesToLabelSpecs maps nodes to labelSpecs
+func mapNodesToLabelSpecs(specs []string, createdNodes []string) (map[string][]string, error) {
+	// check node-specifier possibilitites
+	possibleNodeSpecifiers := []string{"all", "workers", "agents", "server", "master"}
+	possibleNodeSpecifiers = append(possibleNodeSpecifiers, createdNodes...)
+
+	nodeToLabelSpecMap := make(map[string][]string)
+
+	for _, spec := range specs {
+		labelSpec, node := extractLabelNode(spec)
+
+		// check if node-specifier is valid (either a role or a name) and append to list if matches
+		nodeFound := false
+		for _, name := range possibleNodeSpecifiers {
+			if node == name {
+				nodeFound = true
+				nodeToLabelSpecMap[node] = append(nodeToLabelSpecMap[node], labelSpec)
+				break
+			}
+		}
+
+		// node extraction was a false positive, use full spec with default node
+		if !nodeFound {
+			nodeToLabelSpecMap[defaultLabelNodes] = append(nodeToLabelSpecMap[defaultLabelNodes], spec)
+		}
+	}
+
+	return nodeToLabelSpecMap, nil
+}
+
+// extractLabelNode separates the node specification from the actual label specs
+func extractLabelNode(spec string) (string, string) {
+	// label defaults to full spec
+	labelSpec := spec
+
+	// node defaults to "all"
+	node := defaultLabelNodes
+
+	// only split at the last "@"
+	re := regexp.MustCompile(`^(.*)@([^@]+)$`)
+	match := re.FindStringSubmatch(spec)
+
+	if len(match) > 0 {
+		labelSpec = match[1]
+		node = match[2]
+	}
+
+	return labelSpec, node
+}
+
+// splitLabel separates the label key from the label value
+func splitLabel(label string) (string, string) {
+	// split only on first '=' sign (like `docker run` do)
+	labelSlice := strings.SplitN(label, "=", 2)
+
+	if len(labelSlice) > 1 {
+		return labelSlice[0], labelSlice[1]
+	}
+
+	// defaults to label key with empty value (like `docker run` do)
+	return label, ""
+}
+
+// MergeLabelSpecs merges labels for a given node
+func MergeLabelSpecs(nodeToLabelSpecMap map[string][]string, role, name string) ([]string, error) {
+	labelSpecs := []string{}
+
+	// add portSpecs according to node role
+	for _, group := range nodeRuleGroupsMap[role] {
+		for _, v := range nodeToLabelSpecMap[group] {
+			exists := false
+			for _, i := range labelSpecs {
+				if v == i {
+					exists = true
+				}
+			}
+			if !exists {
+				labelSpecs = append(labelSpecs, v)
+			}
+		}
+	}
+
+	// add portSpecs according to node name
+	for _, v := range nodeToLabelSpecMap[name] {
+		exists := false
+		for _, i := range labelSpecs {
+			if v == i {
+				exists = true
+			}
+		}
+		if !exists {
+			labelSpecs = append(labelSpecs, v)
+		}
+	}
+
+	return labelSpecs, nil
+}
+
+// MergeLabels merges list of labels into a label map
+func MergeLabels(labelMap map[string]string, labels []string) map[string]string {
+	for _, label := range labels {
+		labelKey, labelValue := splitLabel(label)
+
+		if _, found := labelMap[labelKey]; found {
+			log.Warningf("Overriding already existing label [%s]", labelKey)
+		}
+
+		labelMap[labelKey] = labelValue
+	}
+
+	return labelMap
+}

--- a/cli/port.go
+++ b/cli/port.go
@@ -93,7 +93,7 @@ func extractNodes(spec string) ([]string, string) {
 	return nodes, portSpec
 }
 
-// Offset creates a new PublishedPort structure, with all host ports are changed by a fixed  'offset'
+// Offset creates a new PublishedPort structure, with all host ports are changed by a fixed 'offset'
 func (p PublishedPorts) Offset(offset int) *PublishedPorts {
 	var newExposedPorts = make(map[nat.Port]struct{}, len(p.ExposedPorts))
 	var newPortBindings = make(map[nat.Port][]nat.PortBinding, len(p.PortBindings))

--- a/cli/port.go
+++ b/cli/port.go
@@ -16,7 +16,7 @@ func mapNodesToPortSpecs(specs []string, createdNodes []string) (map[string][]st
 	}
 
 	// check node-specifier possibilitites
-	possibleNodeSpecifiers := []string{"all", "workers", "server", "master"}
+	possibleNodeSpecifiers := []string{"all", "workers", "agents", "server", "master"}
 	possibleNodeSpecifiers = append(possibleNodeSpecifiers, createdNodes...)
 
 	nodeToPortSpecMap := make(map[string][]string)

--- a/cli/types.go
+++ b/cli/types.go
@@ -37,6 +37,7 @@ type ClusterSpec struct {
 	AutoRestart       bool
 	ClusterName       string
 	Env               []string
+	Labels            []string
 	Image             string
 	NodeToPortSpecMap map[string][]string
 	PortAutoOffset    int

--- a/cli/types.go
+++ b/cli/types.go
@@ -14,6 +14,9 @@ const (
 // defaultNodes describes the type of nodes on which a port should be exposed by default
 const defaultNodes = "server"
 
+// defaultLabelNodes describes the type of nodes on which a label should be applied by default
+const defaultLabelNodes = "all"
+
 // mapping a node role to groups that should be applied to it
 var nodeRuleGroupsMap = map[string][]string{
 	"worker": {"all", "workers", "agents"},
@@ -32,17 +35,17 @@ type Cluster struct {
 
 // ClusterSpec defines the specs for a cluster that's up for creation
 type ClusterSpec struct {
-	AgentArgs         []string
-	APIPort           apiPort
-	AutoRestart       bool
-	ClusterName       string
-	Env               []string
-	Labels            []string
-	Image             string
-	NodeToPortSpecMap map[string][]string
-	PortAutoOffset    int
-	ServerArgs        []string
-	Volumes           *Volumes
+	AgentArgs          []string
+	APIPort            apiPort
+	AutoRestart        bool
+	ClusterName        string
+	Env                []string
+	NodeToLabelSpecMap map[string][]string
+	Image              string
+	NodeToPortSpecMap  map[string][]string
+	PortAutoOffset     int
+	ServerArgs         []string
+	Volumes            *Volumes
 }
 
 // PublishedPorts is a struct used for exposing container ports on the host system

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name:  "label, l",
-					Usage: "Add one or more docker labels to every node container of the cluster, using Docker notation `key=value` (new flag per label)",
+					Usage: "Add a docker label to node container (Format: `key[=value][@node-specifier]`, new flag per label)",
 				},
 				cli.IntFlag{
 					Name:  "workers, w",
@@ -157,10 +157,6 @@ func main() {
 				cli.StringSliceFlag{
 					Name:  "env, e",
 					Usage: "Pass an additional environment variable (new flag per variable)",
-				},
-				cli.StringSliceFlag{
-					Name:  "label, l",
-					Usage: "Add one or more docker labels to every node container of the cluster (Docker notation: `key=value`)",
 				},
 				cli.StringSliceFlag{
 					Name:  "volume, v",

--- a/main.go
+++ b/main.go
@@ -107,6 +107,10 @@ func main() {
 					Name:  "env, e",
 					Usage: "Pass an additional environment variable (new flag per variable)",
 				},
+				cli.StringSliceFlag{
+					Name:  "label, l",
+					Usage: "Add one or more docker labels to every node container of the cluster, using Docker notation `key=value` (new flag per label)",
+				},
 				cli.IntFlag{
 					Name:  "workers, w",
 					Value: 0,
@@ -153,6 +157,10 @@ func main() {
 				cli.StringSliceFlag{
 					Name:  "env, e",
 					Usage: "Pass an additional environment variable (new flag per variable)",
+				},
+				cli.StringSliceFlag{
+					Name:  "label, l",
+					Usage: "Add one or more docker labels to every node container of the cluster (Docker notation: `key=value`)",
 				},
 				cli.StringSliceFlag{
 					Name:  "volume, v",


### PR DESCRIPTION
Some service discovery systems are using docker labels to configure DNS, load-balancing, monitoring, metering ... (ie. [dalidock](https://github.com/lionelnicolas/dalidock) , [traefik](https://docs.traefik.io/providers/docker/#routing-configuration) ...).

This PR introduce ability to set arbitrary docker labels for worker nodes using a new `--label` argument to `k3s create` and `k3d add-node`.