### PR TITLE
[Feature] Add flag for customizing the global registries file

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -210,6 +210,27 @@ func CreateCluster(c *cli.Context) error {
 	volumesSpec.DefaultVolumes = append(volumesSpec.DefaultVolumes, fmt.Sprintf("%s:/images", imageVolume.Name))
 
 	/*
+	 * --registry-file
+	 * check if there is a registries file
+	 */
+	registriesFile := ""
+	if c.IsSet("registries-file") {
+		registriesFile = c.String("registries-file")
+		if !fileExists(registriesFile) {
+			log.Fatalf("registries-file %q does not exists", registriesFile)
+		}
+	} else {
+		registriesFile, err = getGlobalRegistriesConfFilename()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !fileExists(registriesFile) {
+			// if the default registries file does not exists, go ahead but do not try to load it
+			registriesFile = ""
+		}
+	}
+
+	/*
 	 * clusterSpec
 	 * Defines, with which specifications, the cluster and the nodes inside should be created
 	 */
@@ -223,6 +244,7 @@ func CreateCluster(c *cli.Context) error {
 		Image:              image,
 		NodeToPortSpecMap:  portmap,
 		PortAutoOffset:     c.Int("port-auto-offset"),
+		RegistriesFile:     registriesFile,
 		RegistryEnabled:    c.Bool("enable-registry"),
 		RegistryName:       c.String("registry-name"),
 		RegistryPort:       c.Int("registry-port"),

--- a/cli/container.go
+++ b/cli/container.go
@@ -152,7 +152,7 @@ func createServer(spec *ClusterSpec) (string, error) {
 	}
 
 	// copy the registry configuration
-	if spec.RegistryEnabled {
+	if spec.RegistryEnabled || len(spec.RegistriesFile) > 0 {
 		if err := writeRegistriesConfigInContainer(spec, id); err != nil {
 			return "", err
 		}
@@ -250,7 +250,7 @@ func createWorker(spec *ClusterSpec, postfix int) (string, error) {
 	}
 
 	// copy the registry configuration
-	if spec.RegistryEnabled {
+	if spec.RegistryEnabled || len(spec.RegistriesFile) > 0 {
 		if err := writeRegistriesConfigInContainer(spec, id); err != nil {
 			return "", err
 		}

--- a/cli/types.go
+++ b/cli/types.go
@@ -44,6 +44,7 @@ type ClusterSpec struct {
 	Image              string
 	NodeToPortSpecMap  map[string][]string
 	PortAutoOffset     int
+	RegistriesFile     string
 	RegistryEnabled    bool
 	RegistryName       string
 	RegistryPort       int

--- a/cli/util.go
+++ b/cli/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -119,4 +120,9 @@ func parseAPIPort(portSpec string) (*apiPort, error) {
 	}
 
 	return port, nil
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
 }

--- a/main.go
+++ b/main.go
@@ -136,6 +136,10 @@ func main() {
 					Value: defaultRegistryPort,
 					Usage: "Port of the local registry container",
 				},
+				cli.StringFlag{
+					Name:  "registries-file",
+					Usage: "registries.yaml config file",
+				},
 			},
 			Action: run.CreateCluster,
 		},

--- a/tests/01-basic.sh
+++ b/tests/01-basic.sh
@@ -21,6 +21,7 @@ $EXE create --wait 60 --name "c2" --api-port 6444 || failed "could not create cl
 
 info "Checking we have access to both clusters..."
 check_k3d_clusters "c1" "c2" || failed "error checking cluster"
+dump_registries_yaml_in "c1" "c2"
 
 info "Deleting clusters..."
 $EXE delete --name "c1" || failed "could not delete the cluster c1"

--- a/tests/02-registry.sh
+++ b/tests/02-registry.sh
@@ -13,9 +13,11 @@ REGISTRY_PORT="5000"
 REGISTRY="$REGISTRY_NAME:$REGISTRY_PORT"
 TEST_IMAGE="nginx:latest"
 
-check_registry() {
-  check_url $REGISTRY/v2/_catalog
-}
+FIXTURES_DIR=$CURR_DIR/fixtures
+
+# a dummy registries.yaml file
+REGISTRIES_YAML=$FIXTURES_DIR/01-registries-empty.yaml
+
 
 #########################################################################################
 
@@ -32,9 +34,10 @@ fi
 
 info "Creating two clusters (with a registry)..."
 $EXE create --wait 60 --name "c1" --api-port 6443 --enable-registry || failed "could not create cluster c1"
-$EXE create --wait 60 --name "c2" --api-port 6444 --enable-registry || failed "could not create cluster c2"
+$EXE create --wait 60 --name "c2" --api-port 6444 --enable-registry --registries-file "$REGISTRIES_YAML" || failed "could not create cluster c2"
 
 check_k3d_clusters "c1" "c2" || failed "error checking cluster"
+dump_registries_yaml_in "c1" "c2"
 
 check_registry || abort "local registry not available at $REGISTRY"
 passed "Local registry running at $REGISTRY"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -51,6 +51,13 @@ passed() {
   fi
 }
 
+dump_registries_yaml_in() {
+  for cluster in $@ ; do
+    info "registries.yaml in cluster $cluster:"
+    docker exec -t k3d-$cluster-server cat /etc/rancher/k3s/registries.yaml
+  done
+}
+
 # checks that a URL is available, with an optional error message
 check_url() {
   command_exists curl || abort "curl is not installed"
@@ -71,3 +78,8 @@ check_k3d_clusters() {
   done
   return 0
 }
+
+check_registry() {
+  check_url $REGISTRY/v2/_catalog
+}
+


### PR DESCRIPTION
We are currently assuming the `registries.yaml` is located at `~/.k3d/registries.yaml`. This option gives the possibility of customizing this file. It also allows users to customize private registries per cluster.