### PR TITLE
[Feature] New --prune option for delete

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,8 +216,8 @@ func main() {
 					Usage: "Delete all existing clusters (this ignores the --name/-n flag)",
 				},
 				cli.BoolFlag{
-					Name:  "registry-volume",
-					Usage: "Delete the local Docker registry volume",
+					Name:  "prune",
+					Usage: "Disconnect any other non-k3d containers in the network before deleting the cluster",
 				},
 			},
 			Action: run.DeleteCluster,

--- a/tests/01-basic.sh
+++ b/tests/01-basic.sh
@@ -15,7 +15,7 @@ REGISTRIES_YAML=$FIXTURES_DIR/01-registries-empty.yaml
 
 #########################################################################################
 
-info "Creating two clusters..."
+info "Creating two clusters c1 and c2..."
 $EXE create --wait 60 --name "c1" --api-port 6443 -v $REGISTRIES_YAML:/etc/rancher/k3s/registries.yaml || failed "could not create cluster c1"
 $EXE create --wait 60 --name "c2" --api-port 6444 || failed "could not create cluster c2"
 
@@ -23,9 +23,19 @@ info "Checking we have access to both clusters..."
 check_k3d_clusters "c1" "c2" || failed "error checking cluster"
 dump_registries_yaml_in "c1" "c2"
 
-info "Deleting clusters..."
-$EXE delete --name "c1" || failed "could not delete the cluster c1"
-$EXE delete --name "c2" || failed "could not delete the cluster c2"
+info "Creating a cluster with a wrong --registries-file argument..."
+$EXE create --wait 60 --name "c3" --api-port 6445 --registries-file /etc/inexistant || passed "expected error with a --registries-file that does not exist"
+
+info "Attaching a container to c2"
+background=$(docker run -d --rm alpine sleep 3000)
+docker network connect "k3d-c2" "$background"
+
+info "Deleting clusters c1 and c2..."
+$EXE delete --name "c1"         || failed "could not delete the cluster c1"
+$EXE delete --name "c2" --prune || failed "could not delete the cluster c2"
+
+info "Stopping attached container"
+docker stop "$background" >/dev/null
 
 exit 0
 


### PR DESCRIPTION
New option, `--prune`, for `delete`. When forcing a delete, all the containers connected to the k3d network will be disconnected before removing the network.