### PR TITLE
[Feature] Options for keeping/re-using a specific volume for the registry

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -249,6 +249,7 @@ func CreateCluster(c *cli.Context) error {
 		RegistryEnabled:    c.Bool("enable-registry"),
 		RegistryName:       c.String("registry-name"),
 		RegistryPort:       c.Int("registry-port"),
+		RegistryVolume:     c.String("registry-volume"),
 		ServerArgs:         k3sServerArgs,
 		Volumes:            volumesSpec,
 	}
@@ -379,7 +380,7 @@ func DeleteCluster(c *cli.Context) error {
 			return fmt.Errorf(" Couldn't remove server for cluster %s\n%+v", cluster.name, err)
 		}
 
-		if err := disconnectRegistryFromNetwork(cluster.name); err != nil {
+		if err := disconnectRegistryFromNetwork(cluster.name, c.IsSet("keep-registry-volume")); err != nil {
 			log.Warningf("Couldn't disconnect Registry from network %s\n%+v", cluster.name, err)
 		}
 

--- a/cli/types.go
+++ b/cli/types.go
@@ -48,6 +48,7 @@ type ClusterSpec struct {
 	RegistryEnabled    bool
 	RegistryName       string
 	RegistryPort       int
+	RegistryVolume     string
 	ServerArgs         []string
 	Volumes            *Volumes
 }

--- a/main.go
+++ b/main.go
@@ -137,6 +137,10 @@ func main() {
 					Usage: "Port of the local registry container",
 				},
 				cli.StringFlag{
+					Name:  "registry-volume",
+					Usage: "Use a specific volume for the registry storage (will be created if not existing)",
+				},
+				cli.StringFlag{
 					Name:  "registries-file",
 					Usage: "registries.yaml config file",
 				},
@@ -218,6 +222,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "prune",
 					Usage: "Disconnect any other non-k3d containers in the network before deleting the cluster",
+				},
+				cli.BoolFlag{
+					Name:  "keep-registry-volume",
+					Usage: "Do not delete the registry volume",
 				},
 			},
 			Action: run.DeleteCluster,

--- a/tests/02-registry.sh
+++ b/tests/02-registry.sh
@@ -33,7 +33,7 @@ else
 fi
 
 info "Creating two clusters (with a registry)..."
-$EXE create --wait 60 --name "c1" --api-port 6443 --enable-registry || failed "could not create cluster c1"
+$EXE create --wait 60 --name "c1" --api-port 6443 --enable-registry --registry-volume "reg-vol" || failed "could not create cluster c1"
 $EXE create --wait 60 --name "c2" --api-port 6444 --enable-registry --registries-file "$REGISTRIES_YAML" || failed "could not create cluster c2"
 
 check_k3d_clusters "c1" "c2" || failed "error checking cluster"
@@ -43,9 +43,13 @@ check_registry || abort "local registry not available at $REGISTRY"
 passed "Local registry running at $REGISTRY"
 
 info "Deleting c1 cluster: the registry should remain..."
-$EXE delete --name "c1" || failed "could not delete the cluster c1"
+$EXE delete --name "c1" --keep-registry-volume || failed "could not delete the cluster c1"
 check_registry || abort "local registry not available at $REGISTRY after removing c1"
 passed "The local registry is still running"
+
+info "Checking that the reg-vol still exists after removing c1"
+check_volume_exists "reg-vol" || abort "the registry volume 'reg-vol' does not seem to exist"
+passed "reg-vol still exists"
 
 info "Pulling a test image..."
 docker pull $TEST_IMAGE
@@ -84,8 +88,18 @@ kubectl --kubeconfig=$($EXE get-kubeconfig --name "c2") wait --for=condition=ava
 passed "Local registry seems to be usable"
 
 info "Deleting c2 cluster: the registry should be removed now..."
-$EXE delete --name "c2" || failed "could not delete the cluster c2"
+$EXE delete --name "c2" --keep-registry-volume || failed "could not delete the cluster c2"
 check_registry && abort "local registry still running at $REGISTRY"
 passed "The local registry has been removed"
 
+info "Creating a new clusters that uses a registry with an existsing 'reg-vol' volume..."
+check_volume_exists "reg-vol" || abort "the registry volume 'reg-vol' does not exist"
+$EXE create --wait 60 --name "c3" --api-port 6445 --enable-registry --registry-volume "reg-vol" || failed "could not create cluster c3"
+
+info "Deleting c3 cluster: the registry should be removed and, this time, the volume too..."
+$EXE delete --name "c3" || failed "could not delete the cluster c3"
+check_volume_exists "reg-vol" && abort "the registry volume 'reg-vol' still exists"
+passed "'reg-vol' has been removed"
+
 exit 0
+

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -83,3 +83,6 @@ check_registry() {
   check_url $REGISTRY/v2/_catalog
 }
 
+check_volume_exists() {
+  docker volume inspect "$1" >/dev/null 2>&1
+}


### PR DESCRIPTION
* New `--registry-volume` option (for `create`) for using an specific volume in the registry. It can be used for specifying a user-provided volume, but the volume will be created if it does not exist.
* New `--keep-registry-volume` (for `delete`) for preventing the registry volume from being deleted. Users can create new clusters that use that volume by using the `--registry-volume` argument.

