### PR TITLE
[Fix] K3S_SECRET env variable to K3S_CLUSTER_SECRET

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -806,7 +806,7 @@ func AddNode(c *cli.Context) error {
 func addNodeToK3s(c *cli.Context, clusterSpec *ClusterSpec, nodeRole string) error {
 
 	k3sURLEnvVar := fmt.Sprintf("K3S_URL=%s", c.String("k3s"))
-	k3sConnSecretEnvVar := fmt.Sprintf("K3S_SECRET=%s", c.String("k3s-secret"))
+	k3sConnSecretEnvVar := fmt.Sprintf("K3S_CLUSTER_SECRET=%s", c.String("k3s-secret"))
 	if c.IsSet("k3s-token") {
 		k3sConnSecretEnvVar = fmt.Sprintf("K3S_TOKEN=%s", c.String("k3s-token"))
 	}


### PR DESCRIPTION
Little fix :
According to this https://github.com/rancher/k3s/blob/master/README.md#L55
I think K3S cluster secret variable is K3S_CLUSTER_SECRET.