### PR TITLE
[v3/Feature] Add cluster-loadbalancer

### DIFF
--- a/cmd/create/createCluster.go
+++ b/cmd/create/createCluster.go
@@ -69,7 +69,7 @@ func NewCmdCreateCluster() *cobra.Command {
 	/*********
 	 * Flags *
 	 *********/
-	cmd.Flags().StringArrayP("api-port", "a", []string{"6443"}, "Specify the Kubernetes API server port (Format: `--api-port [HOST:]HOSTPORT[@NODEFILTER]`\n - Example: `k3d create -m 3 -a 0.0.0.0:6550@master[0] -a 0.0.0.0:6551@master[1]` ")
+	cmd.Flags().StringP("api-port", "a", k3d.DefaultAPIPort, "Specify the Kubernetes API server port (Format: `--api-port [HOST:]HOSTPORT`\n - Example: `k3d create -m 3 -a 0.0.0.0:6550` ")
 	cmd.Flags().IntP("masters", "m", 1, "Specify how many masters you want to create")
 	cmd.Flags().IntP("workers", "w", 0, "Specify how many workers you want to create")
 	cmd.Flags().String("image", fmt.Sprintf("%s:%s", k3d.DefaultK3sImageRepo, version.GetK3sVersion(false)), "Specify k3s image that you want to use for the nodes")
@@ -83,10 +83,6 @@ func NewCmdCreateCluster() *cobra.Command {
 	cmd.Flags().BoolVar(&createClusterOpts.DisableImageVolume, "no-image-volume", false, "Disable the creation of a volume for importing images")
 
 	/* Multi Master Configuration */
-	// multi-master - general
-	// TODO: implement load-balancer/proxy for multi-master setups
-	cmd.Flags().BoolVar(&createClusterOpts.DisableLoadbalancer, "no-lb", false, "[WIP] Disable automatic deployment of a load balancer in Multi-Master setups")
-	cmd.Flags().String("lb-port", "0.0.0.0:6443", "[WIP] Specify port to be exposed by the master load balancer (Format: `[HOST:]HOSTPORT)")
 
 	// multi-master - datastore
 	// TODO: implement multi-master setups with external data store
@@ -174,64 +170,21 @@ func parseCreateClusterCmd(cmd *cobra.Command, args []string, createClusterOpts 
 	}
 
 	// --api-port
-	apiPortFlags, err := cmd.Flags().GetStringArray("api-port")
+	apiPort, err := cmd.Flags().GetString("api-port")
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// error out if we have more api-ports than masters specified
-	if len(apiPortFlags) > masterCount {
-		log.Fatalf("Cannot expose more api-ports than master nodes exist (%d > %d)", len(apiPortFlags), masterCount)
-	}
-
-	ipPortCombinations := map[string]struct{}{} // only for finding duplicates
-	apiPortFilters := map[string]struct{}{}     // only for deduplication
-	exposeAPIToFiltersMap := map[k3d.ExposeAPI][]string{}
-	for _, apiPortFlag := range apiPortFlags {
-
-		// split the flag value from the node filter
-		apiPortString, filters, err := cliutil.SplitFiltersFromFlag(apiPortFlag)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		// if there's only one master node, we don't need a node filter, but if there's more than one, we need exactly one node filter per api-port flag
-		if len(filters) > 1 || (len(filters) == 0 && masterCount > 1) {
-			log.Fatalf("Exactly one node filter required per '--api-port' flag, but got %d on flag %s", len(filters), apiPortFlag)
-		}
-
-		// add default, if no filter was set and we only have a single master node
-		if len(filters) == 0 && masterCount == 1 {
-			filters = []string{"master[0]"}
-		}
-
-		// only one api-port mapping allowed per master node
-		if _, exists := apiPortFilters[filters[0]]; exists {
-			log.Fatalf("Cannot assign multiple api-port mappings to the same node: duplicate '%s'", filters[0])
-		}
-		apiPortFilters[filters[0]] = struct{}{}
-
-		// parse the port mapping
-		exposeAPI, err := cliutil.ParseAPIPort(apiPortString)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		// error out on duplicates
-		ipPort := fmt.Sprintf("%s:%s", exposeAPI.HostIP, exposeAPI.Port)
-		if _, exists := ipPortCombinations[ipPort]; exists {
-			log.Fatalf("Duplicate IP:PORT combination '%s' for the Api Port is not allowed", ipPort)
-		}
-		ipPortCombinations[ipPort] = struct{}{}
-
-		// add to map
-		exposeAPIToFiltersMap[exposeAPI] = filters
-	}
-
-	// --lb-port
-	lbPort, err := cmd.Flags().GetString("lb-port")
+	// parse the port mapping
+	exposeAPI, err := cliutil.ParseAPIPort(apiPort)
 	if err != nil {
 		log.Fatalln(err)
+	}
+	if exposeAPI.Host == "" {
+		exposeAPI.Host = k3d.DefaultAPIHost
+	}
+	if exposeAPI.HostIP == "" {
+		exposeAPI.HostIP = k3d.DefaultAPIHost
 	}
 
 	// --datastore-endpoint
@@ -319,6 +272,7 @@ func parseCreateClusterCmd(cmd *cobra.Command, args []string, createClusterOpts 
 		Network:           network,
 		Secret:            secret,
 		CreateClusterOpts: createClusterOpts,
+		ExposeAPI:         exposeAPI,
 	}
 
 	// generate list of nodes
@@ -336,7 +290,7 @@ func parseCreateClusterCmd(cmd *cobra.Command, args []string, createClusterOpts 
 			MasterOpts: k3d.MasterOpts{},
 		}
 
-		// TODO: by default, we don't expose an API port, even if we only have a single master: should we change that?
+		// TODO: by default, we don't expose an API port: should we change that?
 		// -> if we want to change that, simply add the exposeAPI struct here
 
 		// first master node will be init node if we have more than one master specified but no external datastore
@@ -361,20 +315,6 @@ func parseCreateClusterCmd(cmd *cobra.Command, args []string, createClusterOpts 
 		}
 
 		cluster.Nodes = append(cluster.Nodes, &node)
-	}
-
-	// add masterOpts
-	for exposeAPI, filters := range exposeAPIToFiltersMap {
-		nodes, err := cliutil.FilterNodes(cluster.Nodes, filters)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		for _, node := range nodes {
-			if node.Role != k3d.MasterRole {
-				log.Fatalf("Node returned by filters '%+v' for exposing the API is not a master node", filters)
-			}
-			node.MasterOpts.ExposeAPI = exposeAPI
-		}
 	}
 
 	// append volumes
@@ -405,15 +345,7 @@ func parseCreateClusterCmd(cmd *cobra.Command, args []string, createClusterOpts 
 	/**********************
 	 * Utility Containers *
 	 **********************/
-
-	// TODO: create load balancer and other util containers // TODO: for now, this will only work with the docker provider (?) -> can replace dynamic docker lookup with static traefik config (?)
-	if masterCount > 1 && !createClusterOpts.DisableLoadbalancer { // TODO: add traefik to the same network and add traefik labels to the master node containers
-		log.Debugln("Creating LB in front of master nodes")
-		cluster.MasterLoadBalancer = &k3d.ClusterLoadbalancer{
-			Image:       k3d.DefaultLBImage,
-			ExposedPort: lbPort,
-		}
-	}
+	// ...
 
 	return cluster
 }

--- a/cmd/create/createNode.go
+++ b/cmd/create/createNode.go
@@ -78,6 +78,7 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, *k3d.Cl
 	}
 
 	// --role
+	// TODO: createNode: for --role=master, update the nginx config and add TLS-SAN and server connection, etc.
 	roleStr, err := cmd.Flags().GetString("role")
 	if err != nil {
 		log.Errorln("No node role specified")

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -37,6 +37,7 @@ import (
 // GetKubeconfig grabs the kubeconfig file from /output from a master node container and puts it into a local directory
 func GetKubeconfig(runtime runtimes.Runtime, cluster *k3d.Cluster) ([]byte, error) {
 	// get all master nodes for the selected cluster
+	// TODO: getKubeconfig: we should make sure, that the master node we're trying to getch is actually running
 	masterNodes, err := runtime.GetNodesByLabel(map[string]string{"k3d.cluster": cluster.Name, "k3d.role": string(k3d.MasterRole)})
 	if err != nil {
 		log.Errorln("Failed to get master nodes")
@@ -49,8 +50,8 @@ func GetKubeconfig(runtime runtimes.Runtime, cluster *k3d.Cluster) ([]byte, erro
 	// prefer a master node, which actually has the port exposed
 	var chosenMaster *k3d.Node
 	chosenMaster = nil
-	APIPort := "6443"      // TODO: use default from types
-	APIHost := "localhost" // TODO: use default from types
+	APIPort := k3d.DefaultAPIPort
+	APIHost := k3d.DefaultAPIHost
 
 	for _, master := range masterNodes {
 		if _, ok := master.Labels["k3d.master.api.port"]; ok {

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:1.16.0-alpine
+
+RUN apk -U --no-cache add curl ca-certificates\
+    && mkdir -p /etc/confd \
+    && curl -sLf https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 > /usr/bin/confd \
+    && chmod +x /usr/bin/confd \
+    && apk del curl
+
+COPY templates /etc/confd/templates/
+COPY conf.d /etc/confd/conf.d/
+COPY nginx-proxy /usr/bin/
+
+ENTRYPOINT nginx-proxy

--- a/proxy/conf.d/nginx.toml
+++ b/proxy/conf.d/nginx.toml
@@ -1,0 +1,7 @@
+[template]
+src = "nginx.tmpl"
+dest = "/etc/nginx/nginx.conf"
+keys = [
+    "SERVERS",
+    "PORT",
+]

--- a/proxy/nginx-proxy
+++ b/proxy/nginx-proxy
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Run confd
+confd -onetime -backend env
+
+# Start nginx
+nginx -g 'daemon off;'

--- a/proxy/templates/nginx.tmpl
+++ b/proxy/templates/nginx.tmpl
@@ -1,0 +1,23 @@
+error_log stderr notice;
+
+worker_processes auto;
+events {
+  multi_accept on;
+  use epoll;
+  worker_connections 1024;
+}
+
+stream {
+  upstream kube_apiserver {
+    {{ $servers := split (getenv "SERVERS") "," }}{{range $servers}}
+    server {{.}}:{{getenv "PORT"}};
+    {{end}}
+  }
+
+  server {
+    listen        {{getenv "PORT"}};
+    proxy_pass    kube_apiserver;
+    proxy_timeout 30;
+    proxy_connect_timeout 2s;
+  }
+}

--- a/tests/test_multi_master.sh
+++ b/tests/test_multi_master.sh
@@ -7,7 +7,7 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$CURR_DIR/common.sh"
 
 info "Creating cluster multimaster..."
-$EXE create cluster "multimaster" --masters 3 --api-port '6443@master[0]' --wait 360 || failed "could not create cluster multimaster"
+$EXE create cluster "multimaster" --masters 3 --api-port 6443 --wait 360 || failed "could not create cluster multimaster"
 
 info "Checking we have access to the cluster..."
 check_k3d_clusters "multimaster" || failed "error checking cluster"


### PR DESCRIPTION
We're now creating a nginx proxy container in front of every cluster which proxies requests to the master nodes of that cluster. That way, we only need to expose a single port for multiple master nodes.
Discussed with @galal-hussein, based on PR #214, thanks!
