### PR TITLE
[Feature] add `--dns` flag for k3d create cluster/node

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -20,7 +20,9 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -124,6 +126,11 @@ func createServer(spec *ClusterSpec) (string, error) {
 		Init:         &[]bool{true}[0],
 	}
 
+	// merge clusterSpec hostConfig on top of the local hostConfig
+	if err := mergo.Merge(hostConfig, spec.HostConfig); err != nil {
+		return "", err
+	}
+
 	if spec.AutoRestart {
 		hostConfig.RestartPolicy.Name = "unless-stopped"
 	}
@@ -219,6 +226,11 @@ func createWorker(spec *ClusterSpec, postfix int) (string, error) {
 		PortBindings: workerPublishedPorts.PortBindings,
 		Privileged:   true,
 		Init:         &[]bool{true}[0],
+	}
+
+	// merge clusterSpec hostConfig on top of the local hostConfig
+	if err := mergo.Merge(hostConfig, spec.HostConfig); err != nil {
+		return "", err
 	}
 
 	if spec.AutoRestart {

--- a/cli/registry.go
+++ b/cli/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -177,6 +178,11 @@ func createRegistry(spec ClusterSpec) (string, error) {
 		PortBindings: registryPublishedPorts.PortBindings,
 		Privileged:   true,
 		Init:         &[]bool{true}[0],
+	}
+
+	// merge clusterSpec hostConfig on top of the local hostConfig
+	if err := mergo.Merge(hostConfig, spec.HostConfig); err != nil {
+		return "", err
 	}
 
 	if spec.AutoRestart {

--- a/cli/types.go
+++ b/cli/types.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -40,6 +41,7 @@ type ClusterSpec struct {
 	AutoRestart          bool
 	ClusterName          string
 	Env                  []string
+	HostConfig           *container.HostConfig
 	NodeToLabelSpecMap   map[string][]string
 	Image                string
 	NodeToPortSpecMap    map[string][]string

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/imdario/mergo v0.3.9
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect

--- a/main.go
+++ b/main.go
@@ -150,6 +150,10 @@ func main() {
 					Name:  "enable-registry-cache",
 					Usage: "Use the local registry as a cache for the Docker Hub (Note: This disables pushing local images to the registry!)",
 				},
+				cli.StringSliceFlag{
+					Name:  "dns",
+					Usage: "Set custom DNS servers",
+				},
 			},
 			Action: run.CreateCluster,
 		},


### PR DESCRIPTION
configures all containers with the same DNS HostConfig:
- master
- workers
- registry

for those special cases ...

Related issues:

- https://github.com/rancher/k3s/pull/743