### PR TITLE
[Enhancement] v3/overall: use context.Context in top-level exported functions

### DIFF
--- a/cmd/create/createCluster.go
+++ b/cmd/create/createCluster.go
@@ -64,7 +64,7 @@ func NewCmdCreateCluster() *cobra.Command {
 			cluster := parseCreateClusterCmd(cmd, args, createClusterOpts)
 
 			// check if a cluster with that name exists already
-			if _, err := k3dCluster.GetCluster(cmd.Context(), cluster, runtimes.SelectedRuntime); err == nil {
+			if _, err := k3dCluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, cluster); err == nil {
 				log.Fatalf("Failed to create cluster '%s' because a cluster with that name already exists", cluster.Name)
 			}
 
@@ -73,11 +73,11 @@ func NewCmdCreateCluster() *cobra.Command {
 				log.Debugln("'--update-kubeconfig set: enabling wait-for-master")
 				cluster.CreateClusterOpts.WaitForMaster = true
 			}
-			if err := k3dCluster.CreateCluster(cmd.Context(), cluster, runtimes.SelectedRuntime); err != nil {
+			if err := k3dCluster.CreateCluster(cmd.Context(), runtimes.SelectedRuntime, cluster); err != nil {
 				// rollback if creation failed
 				log.Errorln(err)
 				log.Errorln("Failed to create cluster >>> Rolling Back")
-				if err := k3dCluster.DeleteCluster(cmd.Context(), cluster, runtimes.SelectedRuntime); err != nil {
+				if err := k3dCluster.DeleteCluster(cmd.Context(), runtimes.SelectedRuntime, cluster); err != nil {
 					log.Errorln(err)
 					log.Fatalln("Cluster creation FAILED, also FAILED to rollback changes!")
 				}

--- a/cmd/create/createCluster.go
+++ b/cmd/create/createCluster.go
@@ -64,7 +64,7 @@ func NewCmdCreateCluster() *cobra.Command {
 			cluster := parseCreateClusterCmd(cmd, args, createClusterOpts)
 
 			// check if a cluster with that name exists already
-			if _, err := k3dCluster.GetCluster(cluster, runtimes.SelectedRuntime); err == nil {
+			if _, err := k3dCluster.GetCluster(cmd.Context(), cluster, runtimes.SelectedRuntime); err == nil {
 				log.Fatalf("Failed to create cluster '%s' because a cluster with that name already exists", cluster.Name)
 			}
 
@@ -77,7 +77,7 @@ func NewCmdCreateCluster() *cobra.Command {
 				// rollback if creation failed
 				log.Errorln(err)
 				log.Errorln("Failed to create cluster >>> Rolling Back")
-				if err := k3dCluster.DeleteCluster(cluster, runtimes.SelectedRuntime); err != nil {
+				if err := k3dCluster.DeleteCluster(cmd.Context(), cluster, runtimes.SelectedRuntime); err != nil {
 					log.Errorln(err)
 					log.Fatalln("Cluster creation FAILED, also FAILED to rollback changes!")
 				}
@@ -87,7 +87,7 @@ func NewCmdCreateCluster() *cobra.Command {
 
 			if updateKubeconfig {
 				log.Debugf("Updating default kubeconfig with a new context for cluster %s", cluster.Name)
-				if _, err := k3dCluster.GetAndWriteKubeConfig(runtimes.SelectedRuntime, cluster, "", &k3dCluster.WriteKubeConfigOptions{UpdateExisting: true, OverwriteExisting: false, UpdateCurrentContext: false}); err != nil {
+				if _, err := k3dCluster.GetAndWriteKubeConfig(cmd.Context(), runtimes.SelectedRuntime, cluster, "", &k3dCluster.WriteKubeConfigOptions{UpdateExisting: true, OverwriteExisting: false, UpdateCurrentContext: false}); err != nil {
 					log.Fatalln(err)
 				}
 			}

--- a/cmd/create/createNode.go
+++ b/cmd/create/createNode.go
@@ -45,7 +45,7 @@ func NewCmdCreateNode() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			nodes, cluster := parseCreateNodeCmd(cmd, args)
 			for _, node := range nodes {
-				if err := k3dc.AddNodeToCluster(runtimes.SelectedRuntime, node, cluster); err != nil {
+				if err := k3dc.AddNodeToCluster(cmd.Context(), runtimes.SelectedRuntime, node, cluster); err != nil {
 					log.Errorf("Failed to add node '%s' to cluster '%s'", node.Name, cluster.Name)
 					log.Errorln(err)
 				}

--- a/cmd/delete/deleteCluster.go
+++ b/cmd/delete/deleteCluster.go
@@ -48,11 +48,11 @@ func NewCmdDeleteCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.DeleteCluster(c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.DeleteCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
 						log.Fatalln(err)
 					}
 					log.Infoln("Removing cluster details from default kubeconfig")
-					if err := cluster.RemoveClusterFromDefaultKubeConfig(c); err != nil {
+					if err := cluster.RemoveClusterFromDefaultKubeConfig(cmd.Context(), c); err != nil {
 						log.Warnln("Failed to remove cluster details from default kubeconfig")
 						log.Warnln(err)
 					}
@@ -82,7 +82,7 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	if all, err := cmd.Flags().GetBool("all"); err != nil {
 		log.Fatalln(err)
 	} else if all {
-		clusters, err = cluster.GetClusters(runtimes.SelectedRuntime)
+		clusters, err = cluster.GetClusters(cmd.Context(), runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -94,7 +94,7 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(&k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/delete/deleteCluster.go
+++ b/cmd/delete/deleteCluster.go
@@ -48,7 +48,7 @@ func NewCmdDeleteCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.DeleteCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.DeleteCluster(cmd.Context(), runtimes.SelectedRuntime, c); err != nil {
 						log.Fatalln(err)
 					}
 					log.Infoln("Removing cluster details from default kubeconfig")
@@ -94,7 +94,7 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/delete/deleteNode.go
+++ b/cmd/delete/deleteNode.go
@@ -47,7 +47,7 @@ func NewCmdDeleteNode() *cobra.Command {
 				log.Infoln("No nodes found")
 			} else {
 				for _, node := range nodes {
-					if err := cluster.DeleteNode(runtimes.SelectedRuntime, node); err != nil {
+					if err := cluster.DeleteNode(cmd.Context(), runtimes.SelectedRuntime, node); err != nil {
 						log.Fatalln(err)
 					}
 				}
@@ -75,7 +75,7 @@ func parseDeleteNodeCmd(cmd *cobra.Command, args []string) []*k3d.Node {
 	if all, err := cmd.Flags().GetBool("all"); err != nil {
 		log.Fatalln(err)
 	} else if all {
-		nodes, err = cluster.GetNodes(runtimes.SelectedRuntime)
+		nodes, err = cluster.GetNodes(cmd.Context(), runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -87,7 +87,7 @@ func parseDeleteNodeCmd(cmd *cobra.Command, args []string) []*k3d.Node {
 	}
 
 	for _, name := range args {
-		node, err := cluster.GetNode(&k3d.Node{Name: name}, runtimes.SelectedRuntime)
+		node, err := cluster.GetNode(cmd.Context(), &k3d.Node{Name: name}, runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/delete/deleteNode.go
+++ b/cmd/delete/deleteNode.go
@@ -87,7 +87,7 @@ func parseDeleteNodeCmd(cmd *cobra.Command, args []string) []*k3d.Node {
 	}
 
 	for _, name := range args {
-		node, err := cluster.GetNode(cmd.Context(), &k3d.Node{Name: name}, runtimes.SelectedRuntime)
+		node, err := cluster.GetNode(cmd.Context(), runtimes.SelectedRuntime, &k3d.Node{Name: name})
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/get/getCluster.go
+++ b/cmd/get/getCluster.go
@@ -58,7 +58,7 @@ func NewCmdGetCluster() *cobra.Command {
 				}
 				existingClusters = append(existingClusters, found...)
 			} else { // Option b) cluster name specified -> get specific cluster
-				found, err := cluster.GetCluster(cmd.Context(), clusters, runtimes.SelectedRuntime)
+				found, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, clusters)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/cmd/get/getCluster.go
+++ b/cmd/get/getCluster.go
@@ -52,13 +52,13 @@ func NewCmdGetCluster() *cobra.Command {
 			clusters, headersOff := parseGetClusterCmd(cmd, args)
 			var existingClusters []*k3d.Cluster
 			if clusters == nil { // Option a)  no cluster name specified -> get all clusters
-				found, err := cluster.GetClusters(runtimes.SelectedRuntime)
+				found, err := cluster.GetClusters(cmd.Context(), runtimes.SelectedRuntime)
 				if err != nil {
 					log.Fatalln(err)
 				}
 				existingClusters = append(existingClusters, found...)
 			} else { // Option b) cluster name specified -> get specific cluster
-				found, err := cluster.GetCluster(clusters, runtimes.SelectedRuntime)
+				found, err := cluster.GetCluster(cmd.Context(), clusters, runtimes.SelectedRuntime)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/cmd/get/getKubeconfig.go
+++ b/cmd/get/getKubeconfig.go
@@ -63,7 +63,7 @@ func NewCmdGetKubeconfig() *cobra.Command {
 
 			// generate list of clusters
 			if getKubeconfigFlags.all {
-				clusters, err = cluster.GetClusters(runtimes.SelectedRuntime)
+				clusters, err = cluster.GetClusters(cmd.Context(), runtimes.SelectedRuntime)
 				if err != nil {
 					log.Fatalln(err)
 				}
@@ -77,7 +77,7 @@ func NewCmdGetKubeconfig() *cobra.Command {
 			errorGettingKubeconfig := false
 			for _, c := range clusters {
 				log.Debugf("Getting kubeconfig for cluster '%s'", c.Name)
-				if getKubeconfigFlags.output, err = cluster.GetAndWriteKubeConfig(runtimes.SelectedRuntime, c, getKubeconfigFlags.output, &writeKubeConfigOptions); err != nil {
+				if getKubeconfigFlags.output, err = cluster.GetAndWriteKubeConfig(cmd.Context(), runtimes.SelectedRuntime, c, getKubeconfigFlags.output, &writeKubeConfigOptions); err != nil {
 					log.Errorln(err)
 					errorGettingKubeconfig = true
 				}

--- a/cmd/get/getNode.go
+++ b/cmd/get/getNode.go
@@ -56,7 +56,7 @@ func NewCmdGetNode() *cobra.Command {
 				}
 				existingNodes = append(existingNodes, found...)
 			} else { // Option b) cluster name specified -> get specific cluster
-				found, err := cluster.GetNode(cmd.Context(), node, runtimes.SelectedRuntime)
+				found, err := cluster.GetNode(cmd.Context(), runtimes.SelectedRuntime, node)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/cmd/get/getNode.go
+++ b/cmd/get/getNode.go
@@ -50,13 +50,13 @@ func NewCmdGetNode() *cobra.Command {
 			node, headersOff := parseGetNodeCmd(cmd, args)
 			var existingNodes []*k3d.Node
 			if node == nil { // Option a)  no name specified -> get all nodes
-				found, err := cluster.GetNodes(runtimes.SelectedRuntime)
+				found, err := cluster.GetNodes(cmd.Context(), runtimes.SelectedRuntime)
 				if err != nil {
 					log.Fatalln(err)
 				}
 				existingNodes = append(existingNodes, found...)
 			} else { // Option b) cluster name specified -> get specific cluster
-				found, err := cluster.GetNode(node, runtimes.SelectedRuntime)
+				found, err := cluster.GetNode(cmd.Context(), node, runtimes.SelectedRuntime)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/cmd/load/loadImage.go
+++ b/cmd/load/loadImage.go
@@ -42,7 +42,7 @@ func NewCmdLoadImage() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			images, clusters, keepTarball := parseLoadImageCmd(cmd, args)
-			log.Debugf("Load images [%+v] from runtime [%s] into clusters [%+v]", runtimes.SelectedRuntime, images, clusters)
+			log.Debugf("Load images [%+v] from runtime [%s] into clusters [%+v]", images, runtimes.SelectedRuntime, clusters)
 			for _, cluster := range clusters {
 				log.Debugf("Loading images into '%s'", cluster.Name)
 				if err := tools.LoadImagesIntoCluster(cmd.Context(), runtimes.SelectedRuntime, images, &cluster, keepTarball); err != nil {

--- a/cmd/load/loadImage.go
+++ b/cmd/load/loadImage.go
@@ -45,7 +45,7 @@ func NewCmdLoadImage() *cobra.Command {
 			log.Debugf("Load images [%+v] from runtime [%s] into clusters [%+v]", runtimes.SelectedRuntime, images, clusters)
 			for _, cluster := range clusters {
 				log.Debugf("Loading images into '%s'", cluster.Name)
-				if err := tools.LoadImagesIntoCluster(runtimes.SelectedRuntime, images, &cluster, keepTarball); err != nil {
+				if err := tools.LoadImagesIntoCluster(cmd.Context(), runtimes.SelectedRuntime, images, &cluster, keepTarball); err != nil {
 					log.Errorf("Failed to load images into cluster '%s'", cluster.Name)
 					log.Errorln(err)
 				}

--- a/cmd/start/startCluster.go
+++ b/cmd/start/startCluster.go
@@ -46,7 +46,7 @@ func NewCmdStartCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.StartCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.StartCluster(cmd.Context(), runtimes.SelectedRuntime, c); err != nil {
 						log.Fatalln(err)
 					}
 				}
@@ -85,7 +85,7 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/start/startCluster.go
+++ b/cmd/start/startCluster.go
@@ -46,7 +46,7 @@ func NewCmdStartCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.StartCluster(c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.StartCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
 						log.Fatalln(err)
 					}
 				}
@@ -73,7 +73,7 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	if all, err := cmd.Flags().GetBool("all"); err != nil {
 		log.Fatalln(err)
 	} else if all {
-		clusters, err = cluster.GetClusters(runtimes.SelectedRuntime)
+		clusters, err = cluster.GetClusters(cmd.Context(), runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -85,7 +85,7 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(&k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/start/startNode.go
+++ b/cmd/start/startNode.go
@@ -40,7 +40,7 @@ func NewCmdStartNode() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Debugln("start node called")
 			node := parseStartNodeCmd(cmd, args)
-			if err := runtimes.SelectedRuntime.StartNode(node); err != nil {
+			if err := runtimes.SelectedRuntime.StartNode(cmd.Context(), node); err != nil {
 				log.Fatalln(err)
 			}
 		},

--- a/cmd/stop/stopCluster.go
+++ b/cmd/stop/stopCluster.go
@@ -46,7 +46,7 @@ func NewCmdStopCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.StopCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.StopCluster(cmd.Context(), runtimes.SelectedRuntime, c); err != nil {
 						log.Fatalln(err)
 					}
 				}
@@ -85,7 +85,7 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/stop/stopCluster.go
+++ b/cmd/stop/stopCluster.go
@@ -46,7 +46,7 @@ func NewCmdStopCluster() *cobra.Command {
 				log.Infoln("No clusters found")
 			} else {
 				for _, c := range clusters {
-					if err := cluster.StopCluster(c, runtimes.SelectedRuntime); err != nil {
+					if err := cluster.StopCluster(cmd.Context(), c, runtimes.SelectedRuntime); err != nil {
 						log.Fatalln(err)
 					}
 				}
@@ -73,7 +73,7 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	if all, err := cmd.Flags().GetBool("all"); err != nil {
 		log.Fatalln(err)
 	} else if all {
-		clusters, err = cluster.GetClusters(runtimes.SelectedRuntime)
+		clusters, err = cluster.GetClusters(cmd.Context(), runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -85,7 +85,7 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	for _, name := range args {
-		cluster, err := cluster.GetCluster(&k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
+		cluster, err := cluster.GetCluster(cmd.Context(), &k3d.Cluster{Name: name}, runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/stop/stopNode.go
+++ b/cmd/stop/stopNode.go
@@ -41,7 +41,7 @@ func NewCmdStopNode() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Debugln("stop node called")
 			node := parseStopNodeCmd(cmd, args)
-			if err := runtimes.SelectedRuntime.StopNode(node); err != nil {
+			if err := runtimes.SelectedRuntime.StopNode(cmd.Context(), node); err != nil {
 				log.Fatalln(err)
 			}
 		},

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,7 +39,7 @@ import (
 // CreateCluster creates a new cluster consisting of
 // - some containerized k3s nodes
 // - a docker network
-func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func CreateCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster) error {
 	if cluster.CreateClusterOpts.Timeout > 0*time.Second {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, cluster.CreateClusterOpts.Timeout)
@@ -153,7 +153,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 
 		// create node
 		log.Infof("Creating node '%s'", node.Name)
-		if err := CreateNode(ctx, node, runtime); err != nil {
+		if err := CreateNode(ctx, runtime, node); err != nil {
 			log.Errorln("Failed to create node")
 			return err
 		}
@@ -305,7 +305,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 			}
 			cluster.Nodes = append(cluster.Nodes, lbNode) // append lbNode to list of cluster nodes, so it will be considered during rollback
 			log.Infof("Creating LoadBalancer '%s'", lbNode.Name)
-			if err := CreateNode(ctx, lbNode, runtime); err != nil {
+			if err := CreateNode(ctx, runtime, lbNode); err != nil {
 				log.Errorln("Failed to create loadbalancer")
 				return err
 			}
@@ -317,7 +317,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 }
 
 // DeleteCluster deletes an existing cluster
-func DeleteCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func DeleteCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster) error {
 
 	log.Infof("Deleting cluster '%s'", cluster.Name)
 	log.Debugf("%+v", cluster)
@@ -437,7 +437,7 @@ func populateClusterFieldsFromLabels(cluster *k3d.Cluster) error {
 }
 
 // GetCluster returns an existing cluster with all fields and node lists populated
-func GetCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) (*k3d.Cluster, error) {
+func GetCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster) (*k3d.Cluster, error) {
 	// get nodes that belong to the selected cluster
 	nodes, err := runtime.GetNodesByLabel(map[string]string{"k3d.cluster": cluster.Name})
 	if err != nil {
@@ -471,7 +471,7 @@ func generateNodeName(cluster string, role k3d.Role, suffix int) string {
 }
 
 // StartCluster starts a whole cluster (i.e. all nodes of the cluster)
-func StartCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func StartCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster) error {
 	log.Infof("Starting cluster '%s'", cluster.Name)
 
 	failed := 0
@@ -508,7 +508,7 @@ func StartCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runti
 }
 
 // StopCluster stops a whole cluster (i.e. all nodes of the cluster)
-func StopCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func StopCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster) error {
 	log.Infof("Stopping cluster '%s'", cluster.Name)
 
 	failed := 0

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -153,7 +153,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 
 		// create node
 		log.Infof("Creating node '%s'", node.Name)
-		if err := CreateNode(node, runtime); err != nil {
+		if err := CreateNode(ctx, node, runtime); err != nil {
 			log.Errorln("Failed to create node")
 			return err
 		}
@@ -305,7 +305,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 			}
 			cluster.Nodes = append(cluster.Nodes, lbNode) // append lbNode to list of cluster nodes, so it will be considered during rollback
 			log.Infof("Creating LoadBalancer '%s'", lbNode.Name)
-			if err := CreateNode(lbNode, runtime); err != nil {
+			if err := CreateNode(ctx, lbNode, runtime); err != nil {
 				log.Errorln("Failed to create loadbalancer")
 				return err
 			}
@@ -317,7 +317,7 @@ func CreateCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runt
 }
 
 // DeleteCluster deletes an existing cluster
-func DeleteCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func DeleteCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
 
 	log.Infof("Deleting cluster '%s'", cluster.Name)
 	log.Debugf("%+v", cluster)
@@ -363,7 +363,7 @@ func DeleteCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) error {
 }
 
 // GetClusters returns a list of all existing clusters
-func GetClusters(runtime k3drt.Runtime) ([]*k3d.Cluster, error) {
+func GetClusters(ctx context.Context, runtime k3drt.Runtime) ([]*k3d.Cluster, error) {
 	nodes, err := runtime.GetNodesByLabel(k3d.DefaultObjectLabels)
 	if err != nil {
 		log.Errorln("Failed to get clusters")
@@ -437,7 +437,7 @@ func populateClusterFieldsFromLabels(cluster *k3d.Cluster) error {
 }
 
 // GetCluster returns an existing cluster with all fields and node lists populated
-func GetCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) (*k3d.Cluster, error) {
+func GetCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) (*k3d.Cluster, error) {
 	// get nodes that belong to the selected cluster
 	nodes, err := runtime.GetNodesByLabel(map[string]string{"k3d.cluster": cluster.Name})
 	if err != nil {
@@ -471,7 +471,7 @@ func generateNodeName(cluster string, role k3d.Role, suffix int) string {
 }
 
 // StartCluster starts a whole cluster (i.e. all nodes of the cluster)
-func StartCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func StartCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
 	log.Infof("Starting cluster '%s'", cluster.Name)
 
 	failed := 0
@@ -508,7 +508,7 @@ func StartCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) error {
 }
 
 // StopCluster stops a whole cluster (i.e. all nodes of the cluster)
-func StopCluster(cluster *k3d.Cluster, runtime k3drt.Runtime) error {
+func StopCluster(ctx context.Context, cluster *k3d.Cluster, runtime k3drt.Runtime) error {
 	log.Infof("Stopping cluster '%s'", cluster.Name)
 
 	failed := 0

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -113,7 +113,7 @@ func GetAndWriteKubeConfig(ctx context.Context, runtime runtimes.Runtime, cluste
 func GetKubeconfig(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster) (*clientcmdapi.Config, error) {
 	// get all master nodes for the selected cluster
 	// TODO: getKubeconfig: we should make sure, that the master node we're trying to fetch from is actually running
-	masterNodes, err := runtime.GetNodesByLabel(map[string]string{"k3d.cluster": cluster.Name, "k3d.role": string(k3d.MasterRole)})
+	masterNodes, err := runtime.GetNodesByLabel(ctx, map[string]string{"k3d.cluster": cluster.Name, "k3d.role": string(k3d.MasterRole)})
 	if err != nil {
 		log.Errorln("Failed to get master nodes")
 		return nil, err
@@ -143,7 +143,7 @@ func GetKubeconfig(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.C
 		chosenMaster = masterNodes[0]
 	}
 	// get the kubeconfig from the first master node
-	reader, err := runtime.GetKubeconfig(chosenMaster)
+	reader, err := runtime.GetKubeconfig(ctx, chosenMaster)
 	if err != nil {
 		log.Errorf("Failed to get kubeconfig from node '%s'", chosenMaster.Name)
 		return nil, err

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -23,6 +23,7 @@ package cluster
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -47,10 +48,10 @@ type WriteKubeConfigOptions struct {
 // 1. fetches the KubeConfig from the first master node retrieved for a given cluster
 // 2. modifies it by updating some fields with cluster-specific information
 // 3. writes it to the specified output
-func GetAndWriteKubeConfig(runtime runtimes.Runtime, cluster *k3d.Cluster, output string, writeKubeConfigOptions *WriteKubeConfigOptions) (string, error) {
+func GetAndWriteKubeConfig(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, output string, writeKubeConfigOptions *WriteKubeConfigOptions) (string, error) {
 
 	// get kubeconfig from cluster node
-	kubeconfig, err := GetKubeconfig(runtime, cluster)
+	kubeconfig, err := GetKubeconfig(ctx, runtime, cluster)
 	if err != nil {
 		return output, err
 	}
@@ -65,7 +66,7 @@ func GetAndWriteKubeConfig(runtime runtimes.Runtime, cluster *k3d.Cluster, outpu
 
 	// simply write to the output, ignoring existing contents
 	if writeKubeConfigOptions.OverwriteExisting || output == "-" {
-		return output, WriteKubeConfigToPath(kubeconfig, output)
+		return output, WriteKubeConfigToPath(ctx, kubeconfig, output)
 	}
 
 	// load config from existing file or fail if it has non-kubeconfig contents
@@ -102,14 +103,14 @@ func GetAndWriteKubeConfig(runtime runtimes.Runtime, cluster *k3d.Cluster, outpu
 	}
 
 	// update existing kubeconfig, but error out if there are conflicting fields but we don't want to update them
-	return output, UpdateKubeConfig(kubeconfig, existingKubeConfig, output, writeKubeConfigOptions.UpdateExisting, writeKubeConfigOptions.UpdateCurrentContext)
+	return output, UpdateKubeConfig(ctx, kubeconfig, existingKubeConfig, output, writeKubeConfigOptions.UpdateExisting, writeKubeConfigOptions.UpdateCurrentContext)
 
 }
 
 // GetKubeconfig grabs the kubeconfig file from /output from a master node container,
 // modifies it by updating some fields with cluster-specific information
 // and returns a Config object for further processing
-func GetKubeconfig(runtime runtimes.Runtime, cluster *k3d.Cluster) (*clientcmdapi.Config, error) {
+func GetKubeconfig(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster) (*clientcmdapi.Config, error) {
 	// get all master nodes for the selected cluster
 	// TODO: getKubeconfig: we should make sure, that the master node we're trying to fetch from is actually running
 	masterNodes, err := runtime.GetNodesByLabel(map[string]string{"k3d.cluster": cluster.Name, "k3d.role": string(k3d.MasterRole)})
@@ -199,7 +200,7 @@ func GetKubeconfig(runtime runtimes.Runtime, cluster *k3d.Cluster) (*clientcmdap
 }
 
 // WriteKubeConfigToPath takes a kubeconfig and writes it to some path, which can be '-' for os.Stdout
-func WriteKubeConfigToPath(kubeconfig *clientcmdapi.Config, path string) error {
+func WriteKubeConfigToPath(ctx context.Context, kubeconfig *clientcmdapi.Config, path string) error {
 	var output *os.File
 	defer output.Close()
 	var err error
@@ -234,7 +235,7 @@ func WriteKubeConfigToPath(kubeconfig *clientcmdapi.Config, path string) error {
 }
 
 // UpdateKubeConfig merges a new kubeconfig into an existing kubeconfig and returns the result
-func UpdateKubeConfig(newKubeConfig *clientcmdapi.Config, existingKubeConfig *clientcmdapi.Config, outPath string, overwriteConflicting bool, updateCurrentContext bool) error {
+func UpdateKubeConfig(ctx context.Context, newKubeConfig *clientcmdapi.Config, existingKubeConfig *clientcmdapi.Config, outPath string, overwriteConflicting bool, updateCurrentContext bool) error {
 
 	log.Debugf("Merging new KubeConfig:\n%+v\n>>> into existing KubeConfig:\n%+v", newKubeConfig, existingKubeConfig)
 
@@ -277,11 +278,11 @@ func UpdateKubeConfig(newKubeConfig *clientcmdapi.Config, existingKubeConfig *cl
 
 	log.Debugf("Merged KubeConfig:\n%+v", existingKubeConfig)
 
-	return WriteKubeConfig(existingKubeConfig, outPath)
+	return WriteKubeConfig(ctx, existingKubeConfig, outPath)
 }
 
 // WriteKubeConfig writes a kubeconfig to a path atomically
-func WriteKubeConfig(kubeconfig *clientcmdapi.Config, path string) error {
+func WriteKubeConfig(ctx context.Context, kubeconfig *clientcmdapi.Config, path string) error {
 	tempPath := fmt.Sprintf("%s.k3d_%s", path, time.Now().Format("20060102_150405.000000"))
 	if err := clientcmd.WriteToFile(*kubeconfig, tempPath); err != nil {
 		log.Errorf("Failed to write merged kubeconfig to temporary file '%s'", tempPath)
@@ -319,7 +320,7 @@ func GetDefaultKubeConfigPath() (string, error) {
 }
 
 // RemoveClusterFromDefaultKubeConfig removes a cluster's details from the default kubeconfig
-func RemoveClusterFromDefaultKubeConfig(cluster *k3d.Cluster) error {
+func RemoveClusterFromDefaultKubeConfig(ctx context.Context, cluster *k3d.Cluster) error {
 	defaultKubeConfigPath, err := GetDefaultKubeConfigPath()
 	if err != nil {
 		return err
@@ -328,12 +329,12 @@ func RemoveClusterFromDefaultKubeConfig(cluster *k3d.Cluster) error {
 	if err != nil {
 		return err
 	}
-	kubeconfig = RemoveClusterFromKubeConfig(cluster, kubeconfig)
-	return WriteKubeConfig(kubeconfig, defaultKubeConfigPath)
+	kubeconfig = RemoveClusterFromKubeConfig(ctx, cluster, kubeconfig)
+	return WriteKubeConfig(ctx, kubeconfig, defaultKubeConfigPath)
 }
 
 // RemoveClusterFromKubeConfig removes a cluster's details from a given kubeconfig
-func RemoveClusterFromKubeConfig(cluster *k3d.Cluster, kubeconfig *clientcmdapi.Config) *clientcmdapi.Config {
+func RemoveClusterFromKubeConfig(ctx context.Context, cluster *k3d.Cluster, kubeconfig *clientcmdapi.Config) *clientcmdapi.Config {
 	clusterName := fmt.Sprintf("%s-%s", k3d.DefaultObjectNamePrefix, cluster.Name)
 	contextName := fmt.Sprintf("%s-%s", k3d.DefaultObjectNamePrefix, cluster.Name)
 	authInfoName := fmt.Sprintf("admin@%s-%s", k3d.DefaultObjectNamePrefix, cluster.Name)

--- a/pkg/cluster/loadbalancer.go
+++ b/pkg/cluster/loadbalancer.go
@@ -50,7 +50,7 @@ func AddMasterToLoadBalancer(ctx context.Context, runtime runtimes.Runtime, clus
 	log.Debugf("SERVERS=%s", masterNodes)
 
 	command := fmt.Sprintf("SERVERS=%s %s", masterNodes, "confd -onetime -backend env && nginx -s reload")
-	if err := runtime.ExecInNode(loadbalancer, []string{"sh", "-c", command}); err != nil {
+	if err := runtime.ExecInNode(ctx, loadbalancer, []string{"sh", "-c", command}); err != nil {
 		log.Errorln("Failed to update loadbalancer configuration")
 		return err
 	}

--- a/pkg/cluster/loadbalancer.go
+++ b/pkg/cluster/loadbalancer.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cluster
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rancher/k3d/pkg/runtimes"
@@ -30,7 +31,7 @@ import (
 )
 
 // AddMasterToLoadBalancer adds a new master node to the loadbalancer configuration
-func AddMasterToLoadBalancer(runtime runtimes.Runtime, cluster *k3d.Cluster, newNode *k3d.Node) error {
+func AddMasterToLoadBalancer(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, newNode *k3d.Node) error {
 	// find the LoadBalancer for the target cluster
 	masterNodes := ""
 	var loadbalancer *k3d.Node

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -37,7 +37,7 @@ import (
 
 // AddNodeToCluster adds a node to an existing cluster
 func AddNodeToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, cluster *k3d.Cluster) error {
-	cluster, err := GetCluster(ctx, cluster, runtime)
+	cluster, err := GetCluster(ctx, runtime, cluster)
 	if err != nil {
 		log.Errorf("Failed to find specified cluster '%s'", cluster.Name)
 		return err
@@ -72,7 +72,7 @@ func AddNodeToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 	}
 
 	// get node details
-	chosenNode, err = GetNode(ctx, chosenNode, runtime)
+	chosenNode, err = GetNode(ctx, runtime, chosenNode)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func AddNodeToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 		}
 	}
 
-	if err := CreateNode(ctx, node, runtime); err != nil {
+	if err := CreateNode(ctx, runtime, node); err != nil {
 		return err
 	}
 
@@ -120,16 +120,16 @@ func AddNodeToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 }
 
 // CreateNodes creates a list of nodes
-func CreateNodes(ctx context.Context, nodes []*k3d.Node, runtime runtimes.Runtime) { // TODO: pass `--atomic` flag, so we stop and return an error if any node creation fails?
+func CreateNodes(ctx context.Context, runtime runtimes.Runtime, nodes []*k3d.Node) { // TODO: pass `--atomic` flag, so we stop and return an error if any node creation fails?
 	for _, node := range nodes {
-		if err := CreateNode(ctx, node, runtime); err != nil {
+		if err := CreateNode(ctx, runtime, node); err != nil {
 			log.Error(err)
 		}
 	}
 }
 
 // CreateNode creates a new containerized k3s node
-func CreateNode(ctx context.Context, node *k3d.Node, runtime runtimes.Runtime) error {
+func CreateNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) error {
 	log.Debugf("Creating node from spec\n%+v", node)
 
 	/*
@@ -223,7 +223,7 @@ func GetNodes(ctx context.Context, runtime runtimes.Runtime) ([]*k3d.Node, error
 }
 
 // GetNode returns a node matching the specified node fields
-func GetNode(ctx context.Context, node *k3d.Node, runtime runtimes.Runtime) (*k3d.Node, error) {
+func GetNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) (*k3d.Node, error) {
 	// get node
 	node, err := runtime.GetNode(node)
 	if err != nil {

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -168,7 +168,7 @@ func CreateNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) e
 	/*
 	 * CREATION
 	 */
-	if err := runtime.CreateNode(node); err != nil {
+	if err := runtime.CreateNode(ctx, node); err != nil {
 		return err
 	}
 
@@ -178,7 +178,7 @@ func CreateNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) e
 // DeleteNode deletes an existing node
 func DeleteNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) error {
 
-	if err := runtime.DeleteNode(node); err != nil {
+	if err := runtime.DeleteNode(ctx, node); err != nil {
 		log.Error(err)
 	}
 	return nil
@@ -213,7 +213,7 @@ func patchMasterSpec(node *k3d.Node) error {
 
 // GetNodes returns a list of all existing clusters
 func GetNodes(ctx context.Context, runtime runtimes.Runtime) ([]*k3d.Node, error) {
-	nodes, err := runtime.GetNodesByLabel(k3d.DefaultObjectLabels)
+	nodes, err := runtime.GetNodesByLabel(ctx, k3d.DefaultObjectLabels)
 	if err != nil {
 		log.Errorln("Failed to get nodes")
 		return nil, err
@@ -225,7 +225,7 @@ func GetNodes(ctx context.Context, runtime runtimes.Runtime) ([]*k3d.Node, error
 // GetNode returns a node matching the specified node fields
 func GetNode(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node) (*k3d.Node, error) {
 	// get node
-	node, err := runtime.GetNode(node)
+	node, err := runtime.GetNode(ctx, node)
 	if err != nil {
 		log.Errorf("Failed to get node '%s'", node.Name)
 	}
@@ -243,7 +243,7 @@ func WaitForNodeLogMessage(ctx context.Context, runtime runtimes.Runtime, node *
 		}
 
 		// read the logs
-		out, err := runtime.GetNodeLogs(node)
+		out, err := runtime.GetNodeLogs(ctx, node)
 		if err != nil {
 			if out != nil {
 				out.Close()

--- a/pkg/runtimes/containerd/kubeconfig.go
+++ b/pkg/runtimes/containerd/kubeconfig.go
@@ -23,12 +23,13 @@ THE SOFTWARE.
 package containerd
 
 import (
+	"context"
 	"io"
 
 	k3d "github.com/rancher/k3d/pkg/types"
 )
 
 // GetKubeconfig grabs the kubeconfig from inside a k3d node
-func (d Containerd) GetKubeconfig(node *k3d.Node) (io.ReadCloser, error) {
+func (d Containerd) GetKubeconfig(ctx context.Context, node *k3d.Node) (io.ReadCloser, error) {
 	return nil, nil
 }

--- a/pkg/runtimes/containerd/network.go
+++ b/pkg/runtimes/containerd/network.go
@@ -21,12 +21,14 @@ THE SOFTWARE.
 */
 package containerd
 
+import "context"
+
 // CreateNetworkIfNotPresent creates a new docker network
-func (d Containerd) CreateNetworkIfNotPresent(name string) (string, bool, error) {
+func (d Containerd) CreateNetworkIfNotPresent(ctx context.Context, name string) (string, bool, error) {
 	return "", false, nil
 }
 
 // DeleteNetwork deletes a network
-func (d Containerd) DeleteNetwork(ID string) error {
+func (d Containerd) DeleteNetwork(ctx context.Context, ID string) error {
 	return nil
 }

--- a/pkg/runtimes/containerd/node.go
+++ b/pkg/runtimes/containerd/node.go
@@ -33,11 +33,10 @@ import (
 )
 
 // CreateNode creates a new k3d node
-func (d Containerd) CreateNode(node *k3d.Node) error {
+func (d Containerd) CreateNode(ctx context.Context, node *k3d.Node) error {
 	log.Debugln("containerd.CreateNode...")
 
 	// create containerd client
-	ctx := context.Background()
 	clientOpts := []containerd.ClientOpt{
 		containerd.WithDefaultNamespace("k3d"),
 	}
@@ -77,9 +76,8 @@ func (d Containerd) CreateNode(node *k3d.Node) error {
 }
 
 // DeleteNode deletes an existing k3d node
-func (d Containerd) DeleteNode(node *k3d.Node) error {
+func (d Containerd) DeleteNode(ctx context.Context, node *k3d.Node) error {
 	log.Debugln("containerd.DeleteNode...")
-	ctx := context.Background()
 	clientOpts := []containerd.ClientOpt{
 		containerd.WithDefaultNamespace("k3d"),
 	}
@@ -103,30 +101,30 @@ func (d Containerd) DeleteNode(node *k3d.Node) error {
 }
 
 // StartNode starts an existing node
-func (d Containerd) StartNode(node *k3d.Node) error {
+func (d Containerd) StartNode(ctx context.Context, node *k3d.Node) error {
 	return nil // TODO: fill
 }
 
 // StopNode stops an existing node
-func (d Containerd) StopNode(node *k3d.Node) error {
+func (d Containerd) StopNode(ctx context.Context, node *k3d.Node) error {
 	return nil // TODO: fill
 }
 
-func (d Containerd) GetNodesByLabel(labels map[string]string) ([]*k3d.Node, error) {
+func (d Containerd) GetNodesByLabel(ctx context.Context, labels map[string]string) ([]*k3d.Node, error) {
 	return nil, nil
 }
 
 // GetNode tries to get a node container by its name
-func (d Containerd) GetNode(node *k3d.Node) (*k3d.Node, error) {
+func (d Containerd) GetNode(ctx context.Context, node *k3d.Node) (*k3d.Node, error) {
 	return nil, nil
 }
 
 // GetNodeLogs returns the logs from a given node
-func (d Containerd) GetNodeLogs(node *k3d.Node) (io.ReadCloser, error) {
+func (d Containerd) GetNodeLogs(ctx context.Context, node *k3d.Node) (io.ReadCloser, error) {
 	return nil, nil
 }
 
 // ExecInNode execs a command inside a node
-func (d Containerd) ExecInNode(node *k3d.Node, cmd []string) error {
+func (d Containerd) ExecInNode(ctx context.Context, node *k3d.Node, cmd []string) error {
 	return nil
 }

--- a/pkg/runtimes/containerd/volume.go
+++ b/pkg/runtimes/containerd/volume.go
@@ -21,12 +21,14 @@ THE SOFTWARE.
 */
 package containerd
 
+import "context"
+
 // CreateVolume creates a new named volume
-func (d Containerd) CreateVolume(name string, labels map[string]string) error {
+func (d Containerd) CreateVolume(ctx context.Context, name string, labels map[string]string) error {
 	return nil
 }
 
 // DeleteVolume creates a new named volume
-func (d Containerd) DeleteVolume(name string) error {
+func (d Containerd) DeleteVolume(ctx context.Context, name string) error {
 	return nil
 }

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -57,12 +57,12 @@ func createContainer(ctx context.Context, dockerNode *NodeInDocker, name string)
 		if err != nil {
 			if client.IsErrNotFound(err) {
 				if err := pullImage(&ctx, docker, dockerNode.ContainerConfig.Image); err != nil {
-					log.Errorln("Failed to create container")
+					log.Errorf("Failed to create container '%s'", name)
 					return err
 				}
 				continue
 			}
-			log.Errorln("Failed to create container")
+			log.Errorf("Failed to create container '%s'", name)
 			return err
 		}
 		log.Debugln("Created container", resp.ID)

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -56,7 +56,7 @@ func createContainer(ctx context.Context, dockerNode *NodeInDocker, name string)
 		resp, err = docker.ContainerCreate(ctx, &dockerNode.ContainerConfig, &dockerNode.HostConfig, &dockerNode.NetworkingConfig, name)
 		if err != nil {
 			if client.IsErrNotFound(err) {
-				if err := pullImage(&ctx, docker, dockerNode.ContainerConfig.Image); err != nil {
+				if err := pullImage(ctx, docker, dockerNode.ContainerConfig.Image); err != nil {
 					log.Errorf("Failed to create container '%s'", name)
 					return err
 				}
@@ -107,9 +107,9 @@ func removeContainer(ctx context.Context, ID string) error {
 }
 
 // pullImage pulls a container image and outputs progress if --verbose flag is set
-func pullImage(ctx *context.Context, docker *client.Client, image string) error {
+func pullImage(ctx context.Context, docker *client.Client, image string) error {
 
-	resp, err := docker.ImagePull(*ctx, image, types.ImagePullOptions{})
+	resp, err := docker.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {
 		log.Errorf("Failed to pull image '%s'", image)
 		return err

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -38,12 +38,11 @@ import (
 )
 
 // createContainer creates a new docker container from translated specs
-func createContainer(dockerNode *NodeInDocker, name string) error {
+func createContainer(ctx context.Context, dockerNode *NodeInDocker, name string) error {
 
 	log.Debugf("Creating docker container with translated config\n%+v\n", dockerNode) // TODO: remove?
 
 	// initialize docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -80,10 +79,9 @@ func createContainer(dockerNode *NodeInDocker, name string) error {
 }
 
 // removeContainer deletes a running container (like docker rm -f)
-func removeContainer(ID string) error {
+func removeContainer(ctx context.Context, ID string) error {
 
 	// (0) create docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -135,9 +133,8 @@ func pullImage(ctx *context.Context, docker *client.Client, image string) error 
 
 }
 
-func getNodeContainer(node *k3d.Node) (*types.Container, error) {
+func getNodeContainer(ctx context.Context, node *k3d.Node) (*types.Container, error) {
 	// (0) create docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")

--- a/pkg/runtimes/docker/kubeconfig.go
+++ b/pkg/runtimes/docker/kubeconfig.go
@@ -32,8 +32,7 @@ import (
 )
 
 // GetKubeconfig grabs the kubeconfig from inside a k3d node
-func (d Docker) GetKubeconfig(node *k3d.Node) (io.ReadCloser, error) {
-	ctx := context.Background()
+func (d Docker) GetKubeconfig(ctx context.Context, node *k3d.Node) (io.ReadCloser, error) {
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -41,7 +40,7 @@ func (d Docker) GetKubeconfig(node *k3d.Node) (io.ReadCloser, error) {
 	}
 	defer docker.Close()
 
-	container, err := getNodeContainer(node)
+	container, err := getNodeContainer(ctx, node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtimes/docker/network.go
+++ b/pkg/runtimes/docker/network.go
@@ -34,10 +34,9 @@ import (
 
 // CreateNetworkIfNotPresent creates a new docker network
 // @return: network name, exists, error
-func (d Docker) CreateNetworkIfNotPresent(name string) (string, bool, error) {
+func (d Docker) CreateNetworkIfNotPresent(ctx context.Context, name string) (string, bool, error) {
 
 	// (0) create new docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -82,9 +81,8 @@ func (d Docker) CreateNetworkIfNotPresent(name string) (string, bool, error) {
 }
 
 // DeleteNetwork deletes a network
-func (d Docker) DeleteNetwork(ID string) error {
+func (d Docker) DeleteNetwork(ctx context.Context, ID string) error {
 	// (0) create new docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -97,8 +95,7 @@ func (d Docker) DeleteNetwork(ID string) error {
 }
 
 // GetNetwork gets information about a network by its ID
-func GetNetwork(ID string) (types.NetworkResource, error) {
-	ctx := context.Background()
+func GetNetwork(ctx context.Context, ID string) (types.NetworkResource, error) {
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")

--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -48,7 +48,7 @@ func (d Docker) CreateNode(ctx context.Context, node *k3d.Node) error {
 
 	// create node
 	if err := createContainer(ctx, dockerNode, node.Name); err != nil {
-		log.Errorln("Failed to create k3d node")
+		log.Errorf("Failed to create node '%s'", node.Name)
 		return err
 	}
 

--- a/pkg/runtimes/docker/translate.go
+++ b/pkg/runtimes/docker/translate.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package docker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -92,7 +93,7 @@ func TranslateNodeToContainer(node *k3d.Node) (*NodeInDocker, error) {
 	networkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{
 		node.Network: {},
 	}
-	netInfo, err := GetNetwork(node.Network)
+	netInfo, err := GetNetwork(context.Background(), node.Network)
 	if err != nil {
 		log.Warnln("Failed to get network information")
 		log.Warnln(err)

--- a/pkg/runtimes/docker/volume.go
+++ b/pkg/runtimes/docker/volume.go
@@ -32,9 +32,8 @@ import (
 )
 
 // CreateVolume creates a new named volume
-func (d Docker) CreateVolume(name string, labels map[string]string) error {
+func (d Docker) CreateVolume(ctx context.Context, name string, labels map[string]string) error {
 	// (0) create new docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")
@@ -63,9 +62,8 @@ func (d Docker) CreateVolume(name string, labels map[string]string) error {
 }
 
 // DeleteVolume creates a new named volume
-func (d Docker) DeleteVolume(name string) error {
+func (d Docker) DeleteVolume(ctx context.Context, name string) error {
 	// (0) create new docker client
-	ctx := context.Background()
 	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorln("Failed to create docker client")

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package runtimes
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -41,21 +42,21 @@ var Runtimes = map[string]Runtime{
 
 // Runtime defines an interface that can be implemented for various container runtime environments (docker, containerd, etc.)
 type Runtime interface {
-	CreateNode(*k3d.Node) error
-	DeleteNode(*k3d.Node) error
-	GetNodesByLabel(map[string]string) ([]*k3d.Node, error)
-	GetNode(*k3d.Node) (*k3d.Node, error)
-	CreateNetworkIfNotPresent(name string) (string, bool, error) // @return NETWORK_NAME, EXISTS, ERROR
-	GetKubeconfig(*k3d.Node) (io.ReadCloser, error)
-	DeleteNetwork(ID string) error
-	StartNode(*k3d.Node) error
-	StopNode(*k3d.Node) error
-	CreateVolume(string, map[string]string) error
-	DeleteVolume(string) error
+	CreateNode(context.Context, *k3d.Node) error
+	DeleteNode(context.Context, *k3d.Node) error
+	GetNodesByLabel(context.Context, map[string]string) ([]*k3d.Node, error)
+	GetNode(context.Context, *k3d.Node) (*k3d.Node, error)
+	CreateNetworkIfNotPresent(context.Context, string) (string, bool, error) // @return NETWORK_NAME, EXISTS, ERROR
+	GetKubeconfig(context.Context, *k3d.Node) (io.ReadCloser, error)
+	DeleteNetwork(context.Context, string) error
+	StartNode(context.Context, *k3d.Node) error
+	StopNode(context.Context, *k3d.Node) error
+	CreateVolume(context.Context, string, map[string]string) error
+	DeleteVolume(context.Context, string) error
 	GetRuntimePath() string // returns e.g. '/var/run/docker.sock' for a default docker setup
-	ExecInNode(*k3d.Node, []string) error
+	ExecInNode(context.Context, *k3d.Node, []string) error
 	// DeleteContainer() error
-	GetNodeLogs(*k3d.Node) (io.ReadCloser, error)
+	GetNodeLogs(context.Context, *k3d.Node) (io.ReadCloser, error)
 }
 
 // GetRuntime checks, if a given name is represented by an implemented k3d runtime and returns it

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package tools
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -34,8 +35,8 @@ import (
 
 // LoadImagesIntoCluster starts up a k3d tools container for the selected cluster and uses it to export
 // images from the runtime to import them into the nodes of the selected cluster
-func LoadImagesIntoCluster(runtime runtimes.Runtime, images []string, cluster *k3d.Cluster, keepTarball bool) error {
-	cluster, err := k3dc.GetCluster(cluster, runtime)
+func LoadImagesIntoCluster(ctx context.Context, runtime runtimes.Runtime, images []string, cluster *k3d.Cluster, keepTarball bool) error {
+	cluster, err := k3dc.GetCluster(ctx, cluster, runtime)
 	if err != nil {
 		log.Errorf("Failed to find the specified cluster")
 		return err
@@ -63,6 +64,7 @@ func LoadImagesIntoCluster(runtime runtimes.Runtime, images []string, cluster *k
 	// create tools node to export images
 	log.Infoln("Starting k3d-tools node...")
 	toolsNode, err := startToolsNode( // TODO: re-use existing container
+		ctx,
 		runtime,
 		cluster,
 		cluster.Network.Name,
@@ -123,7 +125,7 @@ func LoadImagesIntoCluster(runtime runtimes.Runtime, images []string, cluster *k
 }
 
 // startToolsNode will start a new k3d tools container and connect it to the network of the chosen cluster
-func startToolsNode(runtime runtimes.Runtime, cluster *k3d.Cluster, network string, volumes []string) (*k3d.Node, error) {
+func startToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, network string, volumes []string) (*k3d.Node, error) {
 	node := &k3d.Node{
 		Name:    fmt.Sprintf("%s-%s-tools", k3d.DefaultObjectNamePrefix, cluster.Name),
 		Image:   k3d.DefaultToolsContainerImage,

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -36,7 +36,7 @@ import (
 // LoadImagesIntoCluster starts up a k3d tools container for the selected cluster and uses it to export
 // images from the runtime to import them into the nodes of the selected cluster
 func LoadImagesIntoCluster(ctx context.Context, runtime runtimes.Runtime, images []string, cluster *k3d.Cluster, keepTarball bool) error {
-	cluster, err := k3dc.GetCluster(ctx, cluster, runtime)
+	cluster, err := k3dc.GetCluster(ctx, runtime, cluster)
 	if err != nil {
 		log.Errorf("Failed to find the specified cluster")
 		return err


### PR DESCRIPTION
- package cluster: use context.Context as first function param in every
exported function
- package cmd: pass cmd.Context() to calls to package cluster exported
functions
- overall: pass context all the way down to the runtime
- createCluster: also wait for master-loadbalancer to be ready (because it makes sense and because we were running in early context cancellation)