### PR TITLE
[Enhancement] installScript: use channel server to fetch latest stable k3s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,12 @@ ifeq ($(GIT_TAG),)
 GIT_TAG   := $(shell git describe --always)
 endif
 
-# get latest k3s version: grep the tag JSON field, extract the tag and replace + with - (difference between git and dockerhub tags)
-ifneq (${GITHUB_API_TOKEN},)
-K3S_TAG		:= $(shell curl --silent -H "Authorization: token:  ${GITHUB_API_TOKEN}" "https://api.github.com/repos/rancher/k3s/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -E 's/\+/\-/')
-else
-K3S_TAG		:= $(shell curl --silent "https://api.github.com/repos/rancher/k3s/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -E 's/\+/\-/')
-endif
+# get latest k3s version: grep the tag and replace + with - (difference between git and dockerhub tags)
+K3S_TAG		:= $(shell curl --silent "https://update.k3s.io/v1-release/channels/stable" | egrep -o '/v[^ ]+"' | sed -E 's/\/|\"//g' | sed -E 's/\+/\-/')
+
 ifeq ($(K3S_TAG),)
 $(warning K3S_TAG undefined: couldn't get latest k3s image tag!)
-$(warning Output of curl: $(shell curl --silent "https://api.github.com/repos/rancher/k3s/releases/latest"))
+$(warning Output of curl: $(shell curl --silent "curl --silent "https://update.k3s.io/v1-release/channels/stable""))
 $(error exiting)
 endif
 


### PR DESCRIPTION
## Problem

- up to now, there's no `latest` tag for k3s docker images
- the latest tag on GitHub (which has been used so far) may be an old k8s version (e.g. right now, it's 1.16.x instead of 1.18.x)

## Solution

Use the stable channel of the channel server and parse the tag from the returned URL (href).
Bonus: no more GitHub API calls that may fail :+1: 

Thanks @davidnuzik for telling me about the channel server :)