### PR TITLE
[Enhancement] Update loadbalancer if handling master nodes

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/imdario/mergo"
 	k3drt "github.com/rancher/k3d/pkg/runtimes"
 	"github.com/rancher/k3d/pkg/types"
 	k3d "github.com/rancher/k3d/pkg/types"
@@ -460,7 +461,22 @@ func GetCluster(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster
 
 	// append nodes
 	for _, node := range nodes {
-		cluster.Nodes = append(cluster.Nodes, node)
+
+		// check if there's already a node in the struct
+		overwroteExisting := false
+		for _, existingNode := range cluster.Nodes {
+
+			// overwrite existing node
+			if existingNode.Name == node.Name {
+				mergo.MergeWithOverwrite(existingNode, node)
+				overwroteExisting = true
+			}
+		}
+
+		// no existing node overwritten: append new node
+		if !overwroteExisting {
+			cluster.Nodes = append(cluster.Nodes, node)
+		}
 	}
 
 	if err := populateClusterFieldsFromLabels(cluster); err != nil {

--- a/pkg/cluster/loadbalancer.go
+++ b/pkg/cluster/loadbalancer.go
@@ -61,7 +61,10 @@ func UpdateLoadbalancerConfig(ctx context.Context, runtime runtimes.Runtime, clu
 
 	command := fmt.Sprintf("SERVERS=%s %s", masterNodes, "confd -onetime -backend env && nginx -s reload")
 	if err := runtime.ExecInNode(ctx, loadbalancer, []string{"sh", "-c", command}); err != nil {
-		log.Errorln("Failed to update loadbalancer configuration")
+		if strings.Contains(err.Error(), "host not found in upstream") {
+			log.Warnf("Loadbalancer configuration updated, but one or more k3d nodes seem to be down, check the logs:\n%s", err.Error())
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
- [x] use idempotent UpdateKubeconfig which takes a fresh list of master
nodes and uses it to update the loadbalancer
- [x] removeNode: use aforementioned function to update the loadbalancer
config when removing a master node
- [x] startNode: Handled by the LB internally --> If it was created before, it should already be present in the LB
- [x] stopNode: Handled by the LB internally --> Backend going down should be handled by the LB