### PR TITLE
[Documentation] get-kubeconfig to retrieve cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Check out what you can do via `k3d help` or check the docs @ [k3d.io](https://k3
 Example Workflow: Create a new cluster and use it with `kubectl`
 
 1. `k3d create cluster CLUSTER_NAME` to create a new single-node cluster (= 1 container running k3s)
-2. `k3d get kubeconfig CLUSTER_NAME --switch` to update your default kubeconfig and switch the current-context to the new one
+2. `export KUBECONFIG="$(k3d get-kubeconfig --name='CLUSTER_NAME')"` to point kubectl to your k3d kubeconfig file
 3. execute some commands like `kubectl get pods --all-namespaces`
 4. `k3d delete cluster CLUSTER_NAME` to delete the default cluster
 


### PR DESCRIPTION
`k3d get kubeconfig` command does not exists. This aims to adjust documentation for next people who wish to give `k3d` a try.

As stated in cluster creation log output
```
  export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
  kubectl cluster-info
```