### PR TITLE
[Feature] Choose random API Port by default

### DIFF
--- a/cmd/create/createCluster.go
+++ b/cmd/create/createCluster.go
@@ -110,7 +110,7 @@ func NewCmdCreateCluster() *cobra.Command {
 	/*********
 	 * Flags *
 	 *********/
-	cmd.Flags().StringP("api-port", "a", "", "Specify the Kubernetes API server port exposed on the LoadBalancer (Format: `--api-port [HOST:]HOSTPORT`)\n - Example: `k3d create -m 3 -a 0.0.0.0:6550`")
+	cmd.Flags().StringP("api-port", "a", "random", "Specify the Kubernetes API server port exposed on the LoadBalancer (Format: `--api-port [HOST:]HOSTPORT`)\n - Example: `k3d create -m 3 -a 0.0.0.0:6550`")
 	cmd.Flags().IntP("masters", "m", 1, "Specify how many masters you want to create")
 	cmd.Flags().IntP("workers", "w", 0, "Specify how many workers you want to create")
 	cmd.Flags().StringP("image", "i", fmt.Sprintf("%s:%s", k3d.DefaultK3sImageRepo, version.GetK3sVersion(false)), "Specify k3s image that you want to use for the nodes")

--- a/cmd/create/createCluster.go
+++ b/cmd/create/createCluster.go
@@ -110,7 +110,7 @@ func NewCmdCreateCluster() *cobra.Command {
 	/*********
 	 * Flags *
 	 *********/
-	cmd.Flags().StringP("api-port", "a", k3d.DefaultAPIPort, "Specify the Kubernetes API server port exposed on the LoadBalancer (Format: `--api-port [HOST:]HOSTPORT`)\n - Example: `k3d create -m 3 -a 0.0.0.0:6550`")
+	cmd.Flags().StringP("api-port", "a", "", "Specify the Kubernetes API server port exposed on the LoadBalancer (Format: `--api-port [HOST:]HOSTPORT`)\n - Example: `k3d create -m 3 -a 0.0.0.0:6550`")
 	cmd.Flags().IntP("masters", "m", 1, "Specify how many masters you want to create")
 	cmd.Flags().IntP("workers", "w", 0, "Specify how many workers you want to create")
 	cmd.Flags().StringP("image", "i", fmt.Sprintf("%s:%s", k3d.DefaultK3sImageRepo, version.GetK3sVersion(false)), "Specify k3s image that you want to use for the nodes")

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -54,14 +54,19 @@ func ParseAPIPort(portString string) (k3d.ExposeAPI, error) {
 	}
 
 	// Verify 'port' is an integer and within port ranges
-	p, err := strconv.Atoi(exposeAPI.Port)
-	if err != nil {
-		return exposeAPI, err
-	}
+	if exposeAPI.Port != "" {
+		p, err := strconv.Atoi(exposeAPI.Port)
+		if err != nil {
+			log.Errorln("Failed to parse port mapping")
+			return exposeAPI, err
+		}
 
-	if p < 0 || p > 65535 {
-		log.Errorln("Failed to parse API Port specification")
-		return exposeAPI, fmt.Errorf("port value '%d' out of range", p)
+		if p < 0 || p > 65535 {
+			log.Errorln("Failed to parse API Port specification")
+			return exposeAPI, fmt.Errorf("port value '%d' out of range", p)
+		}
+	} else {
+		log.Debugf("API-Port Mapping didn't specify hostPort!")
 	}
 
 	return exposeAPI, nil

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -54,15 +54,17 @@ func ParseAPIPort(portString string) (k3d.ExposeAPI, error) {
 	}
 
 	// Verify 'port' is an integer and within port ranges
-	if exposeAPI.Port == "" {
+	if exposeAPI.Port == "" || exposeAPI.Port == "random" {
 		log.Debugf("API-Port Mapping didn't specify hostPort, choosing one randomly...")
 		freePort, err := GetFreePort()
 		if err != nil || freePort == 0 {
-			log.Errorln("Failed to get a free port")
-			return exposeAPI, err
+			log.Warnf("Failed to get random free port:\n%+v", err)
+			log.Warnf("Falling back to default port %s (may be blocked though)...", k3d.DefaultAPIPort)
+			exposeAPI.Port = k3d.DefaultAPIPort
+		} else {
+			exposeAPI.Port = strconv.Itoa(freePort)
+			log.Debugf("Got free port for API: '%d'", freePort)
 		}
-		exposeAPI.Port = strconv.Itoa(freePort)
-		log.Debugf("Got free port for API: '%d'", freePort)
 	}
 	p, err := strconv.Atoi(exposeAPI.Port)
 	if err != nil {

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -54,19 +54,25 @@ func ParseAPIPort(portString string) (k3d.ExposeAPI, error) {
 	}
 
 	// Verify 'port' is an integer and within port ranges
-	if exposeAPI.Port != "" {
-		p, err := strconv.Atoi(exposeAPI.Port)
-		if err != nil {
-			log.Errorln("Failed to parse port mapping")
+	if exposeAPI.Port == "" {
+		log.Debugf("API-Port Mapping didn't specify hostPort, choosing one randomly...")
+		freePort, err := GetFreePort()
+		if err != nil || freePort == 0 {
+			log.Errorln("Failed to get a free port")
 			return exposeAPI, err
 		}
+		exposeAPI.Port = strconv.Itoa(freePort)
+		log.Debugf("Got free port for API: '%d'", freePort)
+	}
+	p, err := strconv.Atoi(exposeAPI.Port)
+	if err != nil {
+		log.Errorln("Failed to parse port mapping")
+		return exposeAPI, err
+	}
 
-		if p < 0 || p > 65535 {
-			log.Errorln("Failed to parse API Port specification")
-			return exposeAPI, fmt.Errorf("port value '%d' out of range", p)
-		}
-	} else {
-		log.Debugf("API-Port Mapping didn't specify hostPort!")
+	if p < 0 || p > 65535 {
+		log.Errorln("Failed to parse API Port specification")
+		return exposeAPI, fmt.Errorf("Port value '%d' out of range", p)
 	}
 
 	return exposeAPI, nil
@@ -76,4 +82,22 @@ func ParseAPIPort(portString string) (k3d.ExposeAPI, error) {
 // ValidatePortMap validates a port mapping
 func ValidatePortMap(portmap string) (string, error) {
 	return portmap, nil // TODO: ValidatePortMap: add validation of port mapping
+}
+
+// GetFreePort tries to fetch an open port from the OS-Kernel
+func GetFreePort() (int, error) {
+	tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		log.Errorln("Failed to resolve address")
+		return 0, err
+	}
+
+	tcpListener, err := net.ListenTCP("tcp", tcpAddress)
+	if err != nil {
+		log.Errorln("Failed to create TCP Listener")
+		return 0, err
+	}
+	defer tcpListener.Close()
+
+	return tcpListener.Addr().(*net.TCPAddr).Port, nil
 }

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -8,7 +8,7 @@ source "$CURR_DIR/common.sh"
 
 info "Creating two clusters..."
 $EXE create cluster c1 --wait --timeout 60s --api-port 6443 || failed "could not create cluster c1"
-$EXE create cluster c2 --wait --timeout 60s --api-port 6444 || failed "could not create cluster c2"
+$EXE create cluster c2 --wait --timeout 60s || failed "could not create cluster c2"
 
 info "Checking that we can get both clusters..."
 check_cluster_count 2


### PR DESCRIPTION
If no `--api-port` was specified or it's set to `random`, we will now try to get a random free port from the OS/Kernel and use that one. If this fails, we'll fallback to the default (6443), just to at least have a chance.

Benefits:
`k3d create cluster one && k3d create cluster two` works without having to worry about choosing free ports to avoid port collisions.