### PR TITLE
[Enhancement] Sane usage of the default cluster name

### DIFF
--- a/cmd/create/createNode.go
+++ b/cmd/create/createNode.go
@@ -62,9 +62,6 @@ func NewCmdCreateNode() *cobra.Command {
 		log.Fatalln("Failed to register flag completion for '--role'", err)
 	}
 	cmd.Flags().StringP("cluster", "c", k3d.DefaultClusterName, "Select the cluster that the node shall connect to.")
-	if err := cmd.MarkFlagRequired("cluster"); err != nil {
-		log.Fatalln("Failed to mark required flag '--cluster'")
-	}
 	if err := cmd.RegisterFlagCompletionFunc("cluster", util.ValidArgsAvailableClusters); err != nil {
 		log.Fatalln("Failed to register flag completion for '--cluster'", err)
 	}

--- a/cmd/delete/deleteCluster.go
+++ b/cmd/delete/deleteCluster.go
@@ -41,10 +41,10 @@ func NewCmdDeleteCluster() *cobra.Command {
 
 	// create new cobra command
 	cmd := &cobra.Command{
-		Use:               "cluster (NAME | --all)",
-		Short:             "Delete a cluster.",
-		Long:              `Delete a cluster.`,
-		Args:              cobra.MinimumNArgs(0), // 0 or n arguments; 0 only if --all is set
+		Use:               "cluster [NAME [NAME ...] | --all]",
+		Short:             "Delete cluster(s).",
+		Long:              `Delete cluster(s).`,
+		Args:              cobra.MinimumNArgs(0), // 0 or n arguments; 0 = default cluster name
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseDeleteClusterCmd(cmd, args)
@@ -106,11 +106,12 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 		return clusters
 	}
 
-	if len(args) < 1 {
-		log.Fatalln("Expecting at least one cluster name if `--all` is not set")
+	clusternames := []string{k3d.DefaultClusterName}
+	if len(args) != 0 {
+		clusternames = args
 	}
 
-	for _, name := range args {
+	for _, name := range clusternames {
 		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)

--- a/cmd/get/getKubeconfig.go
+++ b/cmd/get/getKubeconfig.go
@@ -57,12 +57,7 @@ func NewCmdGetKubeconfig() *cobra.Command {
 		Short:             "Get kubeconfig",
 		Long:              `Get kubeconfig.`,
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) < 1 && !getKubeconfigFlags.all) || (len(args) > 0 && getKubeconfigFlags.all) {
-				return fmt.Errorf("Need to specify one or more cluster names *or* set `--all` flag")
-			}
-			return nil
-		},
+		Args:              cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var clusters []*k3d.Cluster
 			var err error
@@ -78,7 +73,13 @@ func NewCmdGetKubeconfig() *cobra.Command {
 					log.Fatalln(err)
 				}
 			} else {
-				for _, clusterName := range args {
+
+				clusternames := []string{k3d.DefaultClusterName}
+				if len(args) != 0 {
+					clusternames = args
+				}
+
+				for _, clusterName := range clusternames {
 					retrievedCluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: clusterName})
 					if err != nil {
 						log.Fatalln(err)

--- a/cmd/start/startCluster.go
+++ b/cmd/start/startCluster.go
@@ -42,9 +42,9 @@ func NewCmdStartCluster() *cobra.Command {
 
 	// create new command
 	cmd := &cobra.Command{
-		Use:               "cluster (NAME [NAME...] | --all)",
-		Short:             "Start an existing k3d cluster",
-		Long:              `Start an existing k3d cluster`,
+		Use:               "cluster [NAME [NAME...] | --all]",
+		Long:              `Start existing k3d cluster(s)`,
+		Short:             "Start existing k3d cluster(s)",
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseStartClusterCmd(cmd, args)
@@ -86,11 +86,12 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 		return clusters
 	}
 
-	if len(args) < 1 {
-		log.Fatalln("Expecting at least one cluster name if `--all` is not set")
+	clusternames := []string{k3d.DefaultClusterName}
+	if len(args) != 0 {
+		clusternames = args
 	}
 
-	for _, name := range args {
+	for _, name := range clusternames {
 		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)

--- a/cmd/stop/stopCluster.go
+++ b/cmd/stop/stopCluster.go
@@ -37,9 +37,9 @@ func NewCmdStopCluster() *cobra.Command {
 
 	// create new command
 	cmd := &cobra.Command{
-		Use:               "cluster  (NAME [NAME...] | --all)",
-		Short:             "Stop an existing k3d cluster",
-		Long:              `Stop an existing k3d cluster.`,
+		Use:               "cluster [NAME [NAME...] | --all]",
+		Short:             "Stop existing k3d cluster(s)",
+		Long:              `Stop existing k3d cluster(s).`,
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseStopClusterCmd(cmd, args)
@@ -79,11 +79,12 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 		return clusters
 	}
 
-	if len(args) < 1 {
-		log.Fatalln("Expecting at least one cluster name if `--all` is not set")
+	clusternames := []string{k3d.DefaultClusterName}
+	if len(args) != 0 {
+		clusternames = args
 	}
 
-	for _, name := range args {
+	for _, name := range clusternames {
 		cluster, err := cluster.GetCluster(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
 		if err != nil {
 			log.Fatalln(err)


### PR DESCRIPTION
- use by default whereever clustername is required as an arg (if
nArgs is 0)
- use by default whereever clustername is expected as flag

Fixes #291 