### PR TITLE
Handle leading '/' in names for docker runtime

### DIFF
--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -147,7 +147,8 @@ func getNodeContainer(ctx context.Context, node *k3d.Node) (*types.Container, er
 	for k, v := range node.Labels {
 		filters.Add("label", fmt.Sprintf("%s=%s", k, v))
 	}
-	filters.Add("name", fmt.Sprintf("^%s$", node.Name)) // regex filtering for exact name match
+        // See https://github.com/moby/moby/issues/29997 for explanation around initial /
+	filters.Add("name", fmt.Sprintf("^/?%s$", node.Name)) // regex filtering for exact name match
 
 	containers, err := docker.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters,


### PR DESCRIPTION
See: https://github.com/moby/moby/issues/29997

It is possible to find a leading '/' in the name from docker runtime.  This handles the possible presence.