### PR TITLE
[Feature] Node Status

### DIFF
--- a/cmd/cluster/clusterList.go
+++ b/cmd/cluster/clusterList.go
@@ -116,14 +116,14 @@ func PrintClusters(clusters []*k3d.Cluster, flags clusterFlags) {
 	k3cluster.SortClusters(clusters)
 
 	for _, cluster := range clusters {
-		serverCount := cluster.ServerCount()
-		agentCount := cluster.AgentCount()
+		serverCount, serversRunning := cluster.ServerCountRunning()
+		agentCount, agentsRunning := cluster.AgentCountRunning()
 		hasLB := cluster.HasLoadBalancer()
 
 		if flags.token {
-			fmt.Fprintf(tabwriter, "%s\t%d\t%d\t%t\t%s\n", cluster.Name, serverCount, agentCount, hasLB, cluster.Token)
+			fmt.Fprintf(tabwriter, "%s\t%d/%d\t%d/%d\t%t\t%s\n", cluster.Name, serversRunning, serverCount, agentsRunning, agentCount, hasLB, cluster.Token)
 		} else {
-			fmt.Fprintf(tabwriter, "%s\t%d\t%d\t%t\n", cluster.Name, serverCount, agentCount, hasLB)
+			fmt.Fprintf(tabwriter, "%s\t%d/%d\t%d/%d\t%t\n", cluster.Name, serversRunning, serverCount, agentsRunning, agentCount, hasLB)
 		}
 	}
 }

--- a/cmd/node/nodeList.go
+++ b/cmd/node/nodeList.go
@@ -106,7 +106,7 @@ func printNodes(nodes []*k3d.Node, headersOff bool) {
 	defer tabwriter.Flush()
 
 	if !headersOff {
-		headers := []string{"NAME", "ROLE", "CLUSTER"} // TODO: add status
+		headers := []string{"NAME", "ROLE", "CLUSTER", "STATUS"}
 		_, err := fmt.Fprintf(tabwriter, "%s\n", strings.Join(headers, "\t"))
 		if err != nil {
 			log.Fatalln("Failed to print headers")
@@ -118,6 +118,6 @@ func printNodes(nodes []*k3d.Node, headersOff bool) {
 	})
 
 	for _, node := range nodes {
-		fmt.Fprintf(tabwriter, "%s\t%s\t%s\n", strings.TrimPrefix(node.Name, "/"), string(node.Role), node.Labels[k3d.LabelClusterName])
+		fmt.Fprintf(tabwriter, "%s\t%s\t%s\t%s\n", strings.TrimPrefix(node.Name, "/"), string(node.Role), node.Labels[k3d.LabelClusterName], node.State.Status)
 	}
 }

--- a/pkg/runtimes/docker/translate.go
+++ b/pkg/runtimes/docker/translate.go
@@ -175,6 +175,12 @@ func TranslateContainerDetailsToNode(containerDetails types.ContainerJSON) (*k3d
 		}
 	}
 
+	// status
+	nodeState := k3d.NodeState{
+		Running: containerDetails.ContainerJSONBase.State.Running,
+		Status:  containerDetails.ContainerJSONBase.State.Status,
+	}
+
 	node := &k3d.Node{
 		Name:       strings.TrimPrefix(containerDetails.Name, "/"), // container name with leading '/' cut off
 		Role:       k3d.NodeRoles[containerDetails.Config.Labels[k3d.LabelRole]],
@@ -189,6 +195,7 @@ func TranslateContainerDetailsToNode(containerDetails types.ContainerJSON) (*k3d
 		Network:    clusterNetwork,
 		ServerOpts: serverOpts,
 		AgentOpts:  k3d.AgentOpts{},
+		State:      nodeState,
 	}
 	return node, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -181,26 +181,34 @@ type Cluster struct {
 	ImageVolume        string             `yaml:"image_volume" json:"imageVolume,omitempty"`
 }
 
-// ServerCount return number of server node into cluster
-func (c *Cluster) ServerCount() int {
+// ServerCountRunning returns the number of server nodes running in the cluster and the total number
+func (c *Cluster) ServerCountRunning() (int, int) {
 	serverCount := 0
+	serversRunning := 0
 	for _, node := range c.Nodes {
 		if node.Role == ServerRole {
 			serverCount++
+			if node.State.Running {
+				serversRunning++
+			}
 		}
 	}
-	return serverCount
+	return serverCount, serversRunning
 }
 
-// AgentCount return number of agent node into cluster
-func (c *Cluster) AgentCount() int {
+// AgentCountRunning returns the number of agent nodes running in the cluster and the total number
+func (c *Cluster) AgentCountRunning() (int, int) {
 	agentCount := 0
+	agentsRunning := 0
 	for _, node := range c.Nodes {
 		if node.Role == AgentRole {
 			agentCount++
+			if node.State.Running {
+				agentsRunning++
+			}
 		}
 	}
-	return agentCount
+	return agentCount, agentsRunning
 }
 
 // HasLoadBalancer returns true if cluster has a loadbalancer node

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -228,6 +228,7 @@ type Node struct {
 	Network    string            // filled automatically
 	ServerOpts ServerOpts        `yaml:"server_opts" json:"serverOpts,omitempty"`
 	AgentOpts  AgentOpts         `yaml:"agent_opts" json:"agentOpts,omitempty"`
+	State      NodeState         // filled automatically
 }
 
 // ServerOpts describes some additional server role specific opts
@@ -258,4 +259,10 @@ type AgentOpts struct{}
 // GetDefaultObjectName prefixes the passed name with the default prefix
 func GetDefaultObjectName(name string) string {
 	return fmt.Sprintf("%s-%s", DefaultObjectNamePrefix, name)
+}
+
+// NodeState describes the current state of a node
+type NodeState struct {
+	Running bool
+	Status  string
 }


### PR DESCRIPTION
This PR introduces a new node field called `State` which includes a boolean parameter `Running` which indicates if the node is up and running as well as a string value `State` which holds the state string representation (1:1 from docker).
With this, there are two UX improvements:
- `k3d cluster list` now shows how many of the nodes are running
   ```bash
   $ k3d cluster create --agents 3
   ...
   $ k3d node stop k3d-k3s-default-agent-1
   ...
   $ k3d cluster list 
   NAME          SERVERS   AGENTS   LOADBALANCER
   k3s-default   1/1       2/3      true
   ```
- `k3d node list` now shows an additional `Status` column
   ```bash
   $ k3d node list    
   NAME                       ROLE           CLUSTER       STATUS
   k3d-k3s-default-agent-0    agent          k3s-default   running
   k3d-k3s-default-agent-1    agent          k3s-default   exited
   k3d-k3s-default-agent-2    agent          k3s-default   running
   k3d-k3s-default-server-0   server         k3s-default   running
   k3d-k3s-default-serverlb   loadbalancer   k3s-default   running
   ```

Fixes #321 
