### PR TITLE
[Feature] Add Cluster States and Health

### DIFF
--- a/cmd/cluster/clusterList.go
+++ b/cmd/cluster/clusterList.go
@@ -96,7 +96,7 @@ func buildClusterList(ctx context.Context, args []string) []*k3d.Cluster {
 	return clusters
 }
 
-// PrintPrintClusters : display list of cluster
+// PrintClusters : display list of cluster
 func PrintClusters(clusters []*k3d.Cluster, flags clusterFlags) {
 
 	tabwriter := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -93,21 +93,27 @@ var ClusterHealthStates = map[string]ClusterHealth{
 	string(ClusterHealthBroken):           ClusterHealthBroken,
 }
 
-// ClusterState defines a state that a cluster can be in
-type ClusterState string
+// ClusterStatus defines a state that a cluster can be in
+type ClusterStatus string
 
 // possible cluster states
 const (
-	ClusterStateUp      ClusterState = "Up"      // 1 or more servers running
-	ClusterStateDown    ClusterState = "Down"    // no server running
-	ClusterStateStopped ClusterState = "Stopped" // cluster stopped intentionally (k3d cluster stop mycluster)
+	ClusterStatusUp      ClusterStatus = "Up"      // 1 or more servers running
+	ClusterStatusDown    ClusterStatus = "Down"    // no server running
+	ClusterStatusStopped ClusterStatus = "Stopped" // cluster stopped intentionally (k3d cluster stop mycluster)
 )
 
-// ClusterStates defines the possible States a cluster can be in
-var ClusterStates = map[string]ClusterState{
-	string(ClusterStateUp):      ClusterStateUp,
-	string(ClusterStateDown):    ClusterStateDown,
-	string(ClusterStateStopped): ClusterStateStopped,
+// ClusterStatuses defines the possible States a cluster can be in
+var ClusterStatuses = map[string]ClusterStatus{
+	string(ClusterStatusUp):      ClusterStatusUp,
+	string(ClusterStatusDown):    ClusterStatusDown,
+	string(ClusterStatusStopped): ClusterStatusStopped,
+}
+
+// ClusterState consolidates a cluster's status and health into a single struct
+type ClusterState struct {
+	Status ClusterStatus
+	Health ClusterHealth
 }
 
 // DefaultObjectLabels specifies a set of labels that will be attached to k3d objects by default
@@ -217,6 +223,7 @@ type Cluster struct {
 	ExposeAPI          ExposeAPI          `yaml:"expose_api" json:"exposeAPI,omitempty"`
 	ServerLoadBalancer *Node              `yaml:"server_loadbalancer" json:"serverLoadBalancer,omitempty"`
 	ImageVolume        string             `yaml:"image_volume" json:"imageVolume,omitempty"`
+	State              ClusterState       // filled automatically
 }
 
 // ServerCount return number of server node into cluster

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -72,6 +72,44 @@ var NodeRoles = map[string]Role{
 	string(LoadBalancerRole): LoadBalancerRole,
 }
 
+// ClusterHealth describes the health of a cluster
+type ClusterHealth string
+
+// possible health states
+const (
+	ClusterHealthOK               ClusterHealth = "OK"                  // all nodes running
+	ClusterHealthDegraded         ClusterHealth = "Degraded"            // 1+ nodes down
+	ClusterHealthOKModified       ClusterHealth = "OK (Modified)"       // some nodes stopped intentionally, rest is running
+	ClusterHealthDegradedModified ClusterHealth = "Degraded (Modified)" // 1+ nodes down and some more stopped intentionally
+	ClusterHealthBroken           ClusterHealth = "Broken"              // all nodes down
+)
+
+// ClusterHealthStates defines the possible health states for a cluster
+var ClusterHealthStates = map[string]ClusterHealth{
+	string(ClusterHealthOK):               ClusterHealthOK,
+	string(ClusterHealthDegraded):         ClusterHealthDegraded,
+	string(ClusterHealthOKModified):       ClusterHealthOKModified,
+	string(ClusterHealthDegradedModified): ClusterHealthDegradedModified,
+	string(ClusterHealthBroken):           ClusterHealthBroken,
+}
+
+// ClusterState defines a state that a cluster can be in
+type ClusterState string
+
+// possible cluster states
+const (
+	ClusterStateUp      ClusterState = "Up"      // 1 or more servers running
+	ClusterStateDown    ClusterState = "Down"    // no server running
+	ClusterStateStopped ClusterState = "Stopped" // cluster stopped intentionally (k3d cluster stop mycluster)
+)
+
+// ClusterStates defines the possible States a cluster can be in
+var ClusterStates = map[string]ClusterState{
+	string(ClusterStateUp):      ClusterStateUp,
+	string(ClusterStateDown):    ClusterStateDown,
+	string(ClusterStateStopped): ClusterStateStopped,
+}
+
 // DefaultObjectLabels specifies a set of labels that will be attached to k3d objects by default
 var DefaultObjectLabels = map[string]string{
 	"app": "k3d",


### PR DESCRIPTION
This PR adds status and health information for clusters.

- Cluster Status: Whether a cluster is usable or not (i.e. is there at least one server running?)
  - `Up` = all servers running
  - `Stopped` = cluster or all server nodes were stopped intentionally (`k3d cluster/node stop`)
  - `Down` = no server running
- Cluster Health: How many of the nodes belonging to the cluster are running
  - `OK` = all nodes are running
  - `OK (Modified)` = some nodes have been stopped intentionally, the rest is running
  - `Degraded` = some nodes are not running
  - `Degraded (Modified)` = some nodes are not running, but some of them have been stopped intentionally
- Cluster State = Cluster Status + Cluster Health