### PR TITLE
Fix install.sh script if curl is not present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ checkLatestVersion() {
   if type "curl" > /dev/null; then
     TAG=$(curl -Ls -o /dev/null -w %{url_effective} $latest_release_url | grep -oE "[^/]+$" )
   elif type "wget" > /dev/null; then
-    TAG=$(wget $latest_release_url --server-response -O /dev/null 2>&1 | awk '/^  Location: /{DEST=$2} END{ print DEST}' | grep -oE "[^/]+$")
+    TAG=$(wget $latest_release_url --server-response -O /dev/null 2>&1 | awk '/^\s*Location: /{DEST=$2} END{ print DEST}' | grep -oE "[^/]+$")
   fi
 }
 


### PR DESCRIPTION
At least with bash 5.0.18, GNU Wget 1.20.3 and GNU Awk 5.1.0 the wget installation methods fails because the awk regex does not match the location header. In these versions, instead of `/^  Location:...` it must be `/^Location:...`. In order to retain compatibility with other versions having a different behavior, I changed it to `/^\s*Location:...`.

```
bash-5.0$ wget https://github.com/rancher/k3d/releases/latest --server-response -O /dev/null 2>&1 | awk '/^  Location: /{DEST=$2} END{ print DEST}'

bash-5.0$ wget https://github.com/rancher/k3d/releases/latest --server-response -O /dev/null 2>&1 | awk '/^Location: /{DEST=$2} END{ print DEST}'
https://github.com/rancher/k3d/releases/tag/v3.3.0

bash-5.0$ wget https://github.com/rancher/k3d/releases/latest --server-response -O /dev/null 2>&1 | awk '/^\s*Location: /{DEST=$2} END{ print DEST}'
https://github.com/rancher/k3d/releases/tag/v3.3.0
```

This also adds drone steps to test this script with both curl and wget.