### PR TITLE
[Feature] Options for formatted output of `cluster list` (#416, @inercia))

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	google.golang.org/grpc v1.33.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools/v3 v3.0.2 // indirect
 	k8s.io/client-go v0.17.0
 	k8s.io/utils v0.0.0-20200109141947-94aeca20bf09 // indirect

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -182,10 +182,10 @@ type Cluster struct {
 	Token              string             `yaml:"cluster_token" json:"clusterToken,omitempty"`
 	Nodes              []*Node            `yaml:"nodes" json:"nodes,omitempty"`
 	InitNode           *Node              // init server node
-	ExternalDatastore  ExternalDatastore  `yaml:"external_datastore" json:"externalDatastore,omitempty"`
-	CreateClusterOpts  *ClusterCreateOpts `yaml:"options" json:"options,omitempty"`
+	ExternalDatastore  *ExternalDatastore `yaml:"external_datastore,omitempty" json:"externalDatastore,omitempty"`
+	CreateClusterOpts  *ClusterCreateOpts `yaml:"options,omitempty" json:"options,omitempty"`
 	ExposeAPI          ExposeAPI          `yaml:"expose_api" json:"exposeAPI,omitempty"`
-	ServerLoadBalancer *Node              `yaml:"server_loadbalancer" json:"serverLoadBalancer,omitempty"`
+	ServerLoadBalancer *Node              `yaml:"server_loadbalancer,omitempty" json:"serverLoadBalancer,omitempty"`
 	ImageVolume        string             `yaml:"image_volume" json:"imageVolume,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -366,6 +366,7 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gotest.tools/v3 v3.0.2
 ## explicit


### PR DESCRIPTION
This adds a `--ouput` flag to `cluster list` for dumping the list of clusters as a JSON or YAML document.

For example, for YAML (with `k3d cluster list -o yaml --token`):

```yaml
- cluster:
    name: k3s-default
    network:
      name: 96eedd1892479898fa6770ba44f49722d0b3fed7a11d0c70f7afb9db672d52c1
      external: false
    cluster_token: SJbxdPAfVZAlhvYthoHh
    nodes:
    - name: k3d-k3s-default-serverlb
      role: loadbalancer
      image: sha256:1a80a007dbdf22e9361de963b5f7c988f87562be86ceaf8820eca9757a9f6d2a
      volumes: []
      env:
      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
      cmd: []
      extra_args: []
      port_mappings:
      - 0.0.0.0:41751:6443/tcp
      restart: true
      labels:
        k3d.cluster: k3s-default
        k3d.role: loadbalancer
      network: k3d-k3s-default
      extrahosts: []
      server_opts:
        is_initializing_server: false
        exposeapi:
          host: ""
          host_ip: ""
          port: ""
      agent_opts: {}
      gpurequest: ""
      state:
        running: true
        status: running
    - name: k3d-k3s-default-server-0
      role: server
      image: sha256:636f2028a1fb0e79ac2167ad0aae4336150fb85965d91fe6a5357a73985bf80e
      volumes:
      - k3d-k3s-default-images:/k3d/images
      env:
      - K3S_TOKEN=SJbxdPAfVZAlhvYthoHh
      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
      cmd:
      - server
      - --tls-san
      - 0.0.0.0
      extra_args: []
      port_mappings: []
      restart: true
      labels:
        k3d.cluster: k3s-default
        k3d.cluster.imageVolume: k3d-k3s-default-images
        k3d.cluster.network: 96eedd1892479898fa6770ba44f49722d0b3fed7a11d0c70f7afb9db672d52c1
        k3d.cluster.network.external: "false"
        k3d.cluster.token: SJbxdPAfVZAlhvYthoHh
        k3d.cluster.url: https://k3d-k3s-default-server-0:6443
        k3d.role: server
        k3d.server.api.host: 0.0.0.0
        k3d.server.api.hostIP: 0.0.0.0
        k3d.server.api.port: "41751"
      network: k3d-k3s-default
      extrahosts: []
      server_opts:
        is_initializing_server: false
        exposeapi:
          host: 0.0.0.0
          host_ip: 0.0.0.0
          port: "41751"
      agent_opts: {}
      gpurequest: ""
      state:
        running: true
        status: running
    initnode: null
    external_datastore:
      endpoint: ""
      ca_file: ""
      cert_file: ""
      key_file: ""
      network: ""
    options: null
    expose_api:
      host: ""
      host_ip: ""
      port: ""
    server_loadbalancer: null
    image_volume: k3d-k3s-default-images
  servers_running: 1
  servers_count: 1
  agents_running: 0
  agents_count: 0
  has_lb: true
```

and for JSON (with `k3d cluster list -o json --token | jq .`)

```json
[
  {
    "name": "k3s-default",
    "network": {
      "name": "96eedd1892479898fa6770ba44f49722d0b3fed7a11d0c70f7afb9db672d52c1"
    },
    "clusterToken": "SJbxdPAfVZAlhvYthoHh",
    "nodes": [
      {
        "name": "k3d-k3s-default-serverlb",
        "role": "loadbalancer",
        "image": "sha256:1a80a007dbdf22e9361de963b5f7c988f87562be86ceaf8820eca9757a9f6d2a",
        "env": [
          "K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml"
        ],
        "Cmd": null,
        "portMappings": [
          "0.0.0.0:41751:6443/tcp"
        ],
        "restart": true,
        "Labels": {
          "k3d.cluster": "k3s-default",
          "k3d.role": "loadbalancer"
        },
        "Network": "k3d-k3s-default",
        "ExtraHosts": null,
        "serverOpts": {
          "ExposeAPI": {
            "port": ""
          }
        },
        "agentOpts": {},
        "GPURequest": "",
        "State": {
          "Running": true,
          "Status": "running"
        }
      },
      {
        "name": "k3d-k3s-default-server-0",
        "role": "server",
        "image": "sha256:636f2028a1fb0e79ac2167ad0aae4336150fb85965d91fe6a5357a73985bf80e",
        "volumes": [
          "k3d-k3s-default-images:/k3d/images"
        ],
        "env": [
          "K3S_TOKEN=SJbxdPAfVZAlhvYthoHh",
          "K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml"
        ],
        "Cmd": [
          "server",
          "--tls-san",
          "0.0.0.0"
        ],
        "restart": true,
        "Labels": {
          "k3d.cluster": "k3s-default",
          "k3d.cluster.imageVolume": "k3d-k3s-default-images",
          "k3d.cluster.network": "96eedd1892479898fa6770ba44f49722d0b3fed7a11d0c70f7afb9db672d52c1",
          "k3d.cluster.network.external": "false",
          "k3d.cluster.token": "SJbxdPAfVZAlhvYthoHh",
          "k3d.cluster.url": "https://k3d-k3s-default-server-0:6443",
          "k3d.role": "server",
          "k3d.server.api.host": "0.0.0.0",
          "k3d.server.api.hostIP": "0.0.0.0",
          "k3d.server.api.port": "41751"
        },
        "Network": "k3d-k3s-default",
        "ExtraHosts": null,
        "serverOpts": {
          "ExposeAPI": {
            "host": "0.0.0.0",
            "hostIP": "0.0.0.0",
            "port": "41751"
          }
        },
        "agentOpts": {},
        "GPURequest": "",
        "State": {
          "Running": true,
          "Status": "running"
        }
      }
    ],
    "InitNode": null,
    "externalDatastore": {},
    "exposeAPI": {
      "port": ""
    },
    "imageVolume": "k3d-k3s-default-images",
    "serversRunning": 1,
    "serversCount": 1,
    "agentsRunning": 0,
    "agentsCount": 0,
    "hasLoadbalancer": true
  }
]
```

