### PR TITLE
[Fix] Allow literal @ in flags that have nodefilters

### DIFF
--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -7,7 +7,7 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$CURR_DIR/common.sh"
 
 info "Creating two clusters..."
-$EXE cluster create c1 --wait --timeout 60s --api-port 6443 || failed "could not create cluster c1"
+$EXE cluster create c1 --wait --timeout 60s --api-port 6443 --env 'TEST_VAR=user\@pass\\@server[0]' || failed "could not create cluster c1"
 $EXE cluster create c2 --wait --timeout 60s || failed "could not create cluster c2"
 
 info "Checking that we can get both clusters..."
@@ -15,6 +15,9 @@ check_cluster_count 2
 
 info "Checking we have access to both clusters..."
 check_clusters "c1" "c2" || failed "error checking cluster"
+
+info "Checking cluster env var with escaped @ signs..."
+docker exec k3d-c1-server-0 env | grep -E '^TEST_VAR=user@pass\\$' || failed "Failed to lookup proper env var in container"
 
 info "Check k3s token retrieval"
 check_cluster_token_exist "c1" || failed "could not find cluster token c1"


### PR DESCRIPTION
### util/splitFiltersFromFlag: consider literal @ sign
- literal @s can now be escaped with a preceding backslash
  - use case e.g. `--env HTTPS_PROXY=user:pass\@myproxy.com`
- if the last char before a non-literal @ (designating a following
nodefilter) is a backslash, then it can be escaped with another
backslash (no cascading escapes though)

Fixes #420 