### PR TITLE
[Refactoring/Preparation] use real port structs as prep for registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ E2E_LOG_LEVEL ?= WARN
 E2E_SKIP ?=
 E2E_EXTRA ?=
 E2E_RUNNER_START_TIMEOUT ?= 10
+E2E_HELPER_IMAGE_TAG ?=
 
 ########## Go Build Options ##########
 # Build targets
@@ -168,7 +169,7 @@ test:
 
 e2e: build-docker-dind
 	@echo "Running e2e tests in k3d:$(K3D_IMAGE_TAG)"
-	LOG_LEVEL="$(E2E_LOG_LEVEL)" E2E_SKIP="$(E2E_SKIP)" E2E_EXTRA="$(E2E_EXTRA)" E2E_RUNNER_START_TIMEOUT=$(E2E_RUNNER_START_TIMEOUT) tests/dind.sh "${K3D_IMAGE_TAG}-dind"
+	LOG_LEVEL="$(E2E_LOG_LEVEL)" E2E_SKIP="$(E2E_SKIP)" E2E_EXTRA="$(E2E_EXTRA)" E2E_RUNNER_START_TIMEOUT=$(E2E_RUNNER_START_TIMEOUT) E2E_HELPER_IMAGE_TAG="$(E2E_HELPER_IMAGE_TAG)" tests/dind.sh "${K3D_IMAGE_TAG}-dind"
 
 ci-tests: fmt check e2e
 

--- a/cmd/registry/registryCreate.go
+++ b/cmd/registry/registryCreate.go
@@ -101,7 +101,7 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 	}
 
 	// --port
-	exposePort, err := cliutil.ParseExposePort(ppFlags.Port)
+	exposePort, err := cliutil.ParsePortExposureSpec(ppFlags.Port, k3d.DefaultRegistryPort)
 	if err != nil {
 		log.Errorln("Failed to parse registry port")
 		log.Fatalln(err)
@@ -113,5 +113,5 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 		registryName = fmt.Sprintf("%s-%s", k3d.DefaultObjectNamePrefix, args[0])
 	}
 
-	return &k3d.Registry{Host: registryName, Image: flags.Image, Port: k3d.MappedPort{InternalPort: k3d.DefaultRegistryPort, ExternalPort: exposePort}}, clusters
+	return &k3d.Registry{Host: registryName, Image: flags.Image, ExposureOpts: *exposePort}, clusters
 }

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -330,11 +330,11 @@ func patchServerSpec(node *k3d.Node) error {
 
 	// Add labels and TLS SAN for the exposed API
 	// FIXME: For now, the labels concerning the API on the server nodes are only being used for configuring the kubeconfig
-	node.Labels[k3d.LabelServerAPIHostIP] = node.ServerOpts.ExposeAPI.HostIP // TODO: maybe get docker machine IP here
-	node.Labels[k3d.LabelServerAPIHost] = node.ServerOpts.ExposeAPI.Host
-	node.Labels[k3d.LabelServerAPIPort] = node.ServerOpts.ExposeAPI.Port
+	node.Labels[k3d.LabelServerAPIHostIP] = node.ServerOpts.KubeAPI.Binding.HostIP // TODO: maybe get docker machine IP here
+	node.Labels[k3d.LabelServerAPIHost] = node.ServerOpts.KubeAPI.Host
+	node.Labels[k3d.LabelServerAPIPort] = node.ServerOpts.KubeAPI.Binding.HostPort
 
-	node.Args = append(node.Args, "--tls-san", node.ServerOpts.ExposeAPI.Host) // add TLS SAN for non default host name
+	node.Args = append(node.Args, "--tls-san", node.ServerOpts.KubeAPI.Host) // add TLS SAN for non default host name
 
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -33,19 +33,20 @@ import (
 
 func TestReadSimpleConfig(t *testing.T) {
 
+	exposedAPI := conf.SimpleExposureOpts{}
+	exposedAPI.HostIP = "0.0.0.0"
+	exposedAPI.HostPort = "6443"
+
 	expectedConfig := conf.SimpleConfig{
 		TypeMeta: conf.TypeMeta{
 			APIVersion: "k3d.io/v1alpha1",
 			Kind:       "Simple",
 		},
-		Name:    "test",
-		Servers: 1,
-		Agents:  2,
-		ExposeAPI: k3d.ExposedPort{
-			HostIP: "0.0.0.0",
-			Port:   "6443",
-		},
-		Image: "rancher/k3s:latest",
+		Name:      "test",
+		Servers:   1,
+		Agents:    2,
+		ExposeAPI: exposedAPI,
+		Image:     "rancher/k3s:latest",
 		Volumes: []conf.VolumeWithNodeFilters{
 			{
 				Volume:      "/my/path:/some/path",

--- a/pkg/config/test_assets/config_test_simple.yaml
+++ b/pkg/config/test_assets/config_test_simple.yaml
@@ -3,9 +3,9 @@ kind: Simple
 name: test
 servers: 1
 agents: 2
-exposeAPI:
+kubeAPI:
   hostIP: "0.0.0.0"
-  port: "6443"
+  hostPort: "6443"
 image: rancher/k3s:latest
 volumes:
   - volume: /my/path:/some/path

--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -116,7 +116,7 @@ type SimpleConfig struct {
 	Name         string                  `mapstructure:"name" yaml:"name" json:"name,omitempty"`
 	Servers      int                     `mapstructure:"servers" yaml:"servers" json:"servers,omitempty"` //nolint:lll    // default 1
 	Agents       int                     `mapstructure:"agents" yaml:"agents" json:"agents,omitempty"`    //nolint:lll    // default 0
-	ExposeAPI    k3d.ExposedPort         `mapstructure:"exposeAPI" yaml:"exposeAPI" json:"exposeAPI,omitempty"`
+	ExposeAPI    SimpleExposureOpts      `mapstructure:"kubeAPI" yaml:"kubeAPI" json:"kubeAPI,omitempty"`
 	Image        string                  `mapstructure:"image" yaml:"image" json:"image,omitempty"`
 	Network      string                  `mapstructure:"network" yaml:"network" json:"network,omitempty"`
 	ClusterToken string                  `mapstructure:"clusterToken" yaml:"clusterToken" json:"clusterToken,omitempty"` // default: auto-generated
@@ -126,9 +126,16 @@ type SimpleConfig struct {
 	Options      SimpleConfigOptions     `mapstructure:"options" yaml:"options" json:"options,omitempty"`
 	Env          []EnvVarWithNodeFilters `mapstructure:"env" yaml:"env" json:"env,omitempty"`
 	Registries   struct {
-		Use    []*k3d.Registry `mapstructure:"use" yaml:"use,omitempty" json:"use,omitempty"`
-		Create bool            `mapstructure:"create" yaml:"create,omitempty" json:"create,omitempty"`
+		Use    []string `mapstructure:"use" yaml:"use,omitempty" json:"use,omitempty"`
+		Create bool     `mapstructure:"create" yaml:"create,omitempty" json:"create,omitempty"`
 	} `mapstructure:"registries" yaml:"registries,omitempty" json:"registries,omitempty"`
+}
+
+// SimpleExposureOpts provides a simplified syntax compared to the original k3d.ExposureOpts
+type SimpleExposureOpts struct {
+	Host     string `mapstructure:"host" yaml:"host,omitempty" json:"host,omitempty"`
+	HostIP   string `mapstructure:"hostIP" yaml:"hostIP,omitempty" json:"hostIP,omitempty"`
+	HostPort string `mapstructure:"hostPort" yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
 }
 
 // GetKind implements Config.GetKind

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -57,7 +57,7 @@ func ValidateClusterConfig(ctx context.Context, runtime runtimes.Runtime, config
 	}
 
 	// API-Port cannot be changed when using network=host
-	if config.Cluster.Network.Name == "host" && config.Cluster.ExposeAPI.Port != k3d.DefaultAPIPort {
+	if config.Cluster.Network.Name == "host" && config.Cluster.KubeAPI.Port.Port() != k3d.DefaultAPIPort {
 		// in hostNetwork mode, we're not going to map a hostport. Here it should always use 6443.
 		// Note that hostNetwork mode is super inflexible and since we don't change the backend port (on the container), it will only be one hostmode cluster allowed.
 		return fmt.Errorf("The API Port can not be changed when using 'host' network")
@@ -75,13 +75,6 @@ func ValidateClusterConfig(ctx context.Context, runtime runtimes.Runtime, config
 		for _, volume := range node.Volumes {
 
 			if err := util.ValidateVolumeMount(runtime, volume); err != nil {
-				return err
-			}
-		}
-
-		// ports
-		for _, port := range node.Ports {
-			if err := util.ValidatePortMap(port); err != nil {
 				return err
 			}
 		}

--- a/pkg/runtimes/docker/translate_test.go
+++ b/pkg/runtimes/docker/translate_test.go
@@ -43,7 +43,14 @@ func TestTranslateNodeToContainer(t *testing.T) {
 		Env:     []string{"TEST_KEY_1=TEST_VAL_1"},
 		Cmd:     []string{"server", "--https-listen-port=6443"},
 		Args:    []string{"--some-boolflag"},
-		Ports:   []string{"0.0.0.0:6443:6443/tcp"},
+		Ports: nat.PortMap{
+			"6443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "0.0.0.0",
+					HostPort: "6443",
+				},
+			},
+		},
 		Restart: true,
 		Labels:  map[string]string{k3d.LabelRole: string(k3d.ServerRole), "test_key_1": "test_val_1"},
 	}

--- a/pkg/util/ports.go
+++ b/pkg/util/ports.go
@@ -28,11 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// ValidatePortMap validates a port mapping
-func ValidatePortMap(portmap string) error {
-	return nil // TODO: ValidatePortMap: add validation of port mapping
-}
-
 // GetFreePort tries to fetch an open port from the OS-Kernel
 func GetFreePort() (int, error) {
 	tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:0")

--- a/tests/dind.sh
+++ b/tests/dind.sh
@@ -46,7 +46,13 @@ until docker inspect "$k3de2e" | jq ".[0].State.Running" && docker logs "$k3de2e
 done
 
 # build helper container images
-docker exec --workdir /src "$k3de2e" make build-helper-images
+if [ -z "$E2E_HELPER_IMAGE_TAG" ]; then
+  docker exec --workdir /src "$k3de2e" make build-helper-images
+  # execute tests
+  docker exec "$k3de2e" /src/tests/runner.sh
+else
+  # execute tests
+  docker exec -e "K3D_HELPER_IMAGE_TAG=$E2E_HELPER_IMAGE_TAG" "$k3de2e" /src/tests/runner.sh
+fi
 
-# execute tests
-docker exec "$k3de2e" /src/tests/runner.sh
+


### PR DESCRIPTION
Switch from basic string representations (80:80/tcp) to real struct (nat.PortMap) representations of ports in all structs.
This will allow us to more easily use the various port mappings internally.
The SimpleConfig type still has a more "human-friendly" representation.