### PR TITLE
[Enhancement] clusterDelete: proper node and network handling

### DIFF
--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -100,6 +100,7 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	if all, err := cmd.Flags().GetBool("all"); err != nil {
 		log.Fatalln(err)
 	} else if all {
+		log.Infoln("Deleting all clusters...")
 		clusters, err = client.ClusterList(cmd.Context(), runtimes.SelectedRuntime)
 		if err != nil {
 			log.Fatalln(err)

--- a/docs/usage/guides/registries.md
+++ b/docs/usage/guides/registries.md
@@ -67,7 +67,7 @@ Finally, we can create the cluster, mounting the CA file in the path we specifie
 
 ### Using k3d-managed registries
 
-!!! info "Not ported yet"
+!!! info "Just ported!"
       The k3d-managed registry is available again as of k3d v4.0.0 (January 2021)
 
 #### Create a dedicated registry together with your cluster

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -222,6 +222,11 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 		GlobalEnv:           []string{},          // empty init
 	}
 
+	// ensure, that we have the default object labels
+	for k, v := range k3d.DefaultObjectLabels {
+		clusterCreateOpts.GlobalLabels[k] = v
+	}
+
 	/*
 	 * Registries
 	 */

--- a/pkg/runtimes/containerd/node.go
+++ b/pkg/runtimes/containerd/node.go
@@ -137,3 +137,8 @@ func (d Containerd) ExecInNode(ctx context.Context, node *k3d.Node, cmd []string
 func (d Containerd) ExecInNodeGetLogs(ctx context.Context, node *k3d.Node, cmd []string) (*bufio.Reader, error) {
 	return nil, nil
 }
+
+// GetNodesInNetwork returns all the nodes connected to a given network
+func (d Containerd) GetNodesInNetwork(ctx context.Context, network string) ([]*k3d.Node, error) {
+	return nil, nil
+}

--- a/pkg/runtimes/docker/volume.go
+++ b/pkg/runtimes/docker/volume.go
@@ -45,11 +45,12 @@ func (d Docker) CreateVolume(ctx context.Context, name string, labels map[string
 	// (1) create volume
 	volumeCreateOptions := volume.VolumeCreateBody{
 		Name:       name,
-		Labels:     k3d.DefaultObjectLabels,
+		Labels:     labels,
 		Driver:     "local", // TODO: allow setting driver + opts
 		DriverOpts: map[string]string{},
 	}
-	for k, v := range labels {
+
+	for k, v := range k3d.DefaultObjectLabels {
 		volumeCreateOptions.Labels[k] = v
 	}
 

--- a/pkg/runtimes/errors/errors.go
+++ b/pkg/runtimes/errors/errors.go
@@ -19,30 +19,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package containerd
+package runtimes
 
-import (
-	"context"
+import "errors"
 
-	k3d "github.com/rancher/k3d/v4/pkg/types"
-)
+// ErrRuntimeNetworkNotEmpty describes an error that occurs because a network still has containers connected to it (e.g. cannot be deleted)
+var ErrRuntimeNetworkNotEmpty = errors.New("network not empty")
 
-// CreateNetworkIfNotPresent creates a new docker network
-func (d Containerd) CreateNetworkIfNotPresent(ctx context.Context, name string) (string, bool, error) {
-	return "", false, nil
-}
-
-// DeleteNetwork deletes a network
-func (d Containerd) DeleteNetwork(ctx context.Context, ID string) error {
-	return nil
-}
-
-// ConnectNodeToNetwork connects a node to a network
-func (d Containerd) ConnectNodeToNetwork(ctx context.Context, node *k3d.Node, network string) error {
-	return nil
-}
-
-// DisconnectNodeFromNetwork disconnects a node from a network (u don't say :O)
-func (d Containerd) DisconnectNodeFromNetwork(ctx context.Context, node *k3d.Node, network string) error {
-	return nil
-}
+// ErrRuntimeContainerUnknown describes the situation, where we're inspecting a container that's not obviously managed by k3d
+var ErrRuntimeContainerUnknown = errors.New("container not managed by k3d: missing default label(s)")

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -56,6 +56,7 @@ type Runtime interface {
 	GetNodesByLabel(context.Context, map[string]string) ([]*k3d.Node, error)
 	GetNode(context.Context, *k3d.Node) (*k3d.Node, error)
 	GetNodeStatus(context.Context, *k3d.Node) (bool, string, error)
+	GetNodesInNetwork(context.Context, string) ([]*k3d.Node, error)
 	CreateNetworkIfNotPresent(context.Context, string) (string, bool, error) // @return NETWORK_NAME, EXISTS, ERROR
 	GetKubeconfig(context.Context, *k3d.Node) (io.ReadCloser, error)
 	DeleteNetwork(context.Context, string) error
@@ -72,7 +73,8 @@ type Runtime interface {
 	CopyToNode(context.Context, string, string, *k3d.Node) error  // @param context, source, destination, node
 	WriteToNode(context.Context, []byte, string, *k3d.Node) error // @param context, content, destination, node
 	GetHostIP(context.Context, string) (net.IP, error)
-	ConnectNodeToNetwork(context.Context, *k3d.Node, string) error // @param context, node, network name
+	ConnectNodeToNetwork(context.Context, *k3d.Node, string) error      // @param context, node, network name
+	DisconnectNodeFromNetwork(context.Context, *k3d.Node, string) error // @param context, node, network name
 }
 
 // GetRuntime checks, if a given name is represented by an implemented k3d runtime and returns it

--- a/pkg/util/filter.go
+++ b/pkg/util/filter.go
@@ -174,3 +174,14 @@ func FilterNodes(nodes []*k3d.Node, filters []string) ([]*k3d.Node, error) {
 
 	return filteredNodes, nil
 }
+
+// FilterNodesByRole returns a stripped list of nodes which do match the given role
+func FilterNodesByRole(nodes []*k3d.Node, role k3d.Role) []*k3d.Node {
+	filteredNodes := []*k3d.Node{}
+	for _, node := range nodes {
+		if node.Role == role {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	return filteredNodes
+}

--- a/version/version.go
+++ b/version/version.go
@@ -35,7 +35,7 @@ var Version string
 var HelperVersionOverride string
 
 // K3sVersion should contain the latest version tag of k3s (hardcoded at build time)
-var K3sVersion = "rancher/k3s:v1.20.0-k3s2"
+var K3sVersion = "v1.20.0-k3s2"
 
 // GetVersion returns the version for cli, it gets it from "git describe --tags" or returns "dev" when doing simple go build
 func GetVersion() string {


### PR DESCRIPTION
This comes with several fixes/improvements

- only consider containers that have the default object label (app=k3d)
- handle network deletion
  - check if there are other k3d containers connected
  - if there are only registries, disconnect them
  - if there are non-registry nodes, leave everything as it is
  - if there are any containers connected, that are not automatically
  disconnected, log a warning and continue