### PR TITLE
[Enhancement] Improved listings for nodes & registries (#439, @inercia)

### DIFF
--- a/cmd/node/nodeList.go
+++ b/cmd/node/nodeList.go
@@ -77,7 +77,7 @@ func NewCmdNodeList() *cobra.Command {
 				}
 			}
 
-			// print existing registries
+			// print existing nodes
 			headers := &[]string{}
 			if !nodeListFlags.noHeader {
 				headers = &[]string{"NAME", "ROLE", "CLUSTER", "STATUS"}

--- a/cmd/registry/registryList.go
+++ b/cmd/registry/registryList.go
@@ -82,20 +82,22 @@ func NewCmdRegistryList() *cobra.Command {
 			// print existing registries
 			headers := &[]string{}
 			if !registryListFlags.noHeader {
-				headers = &[]string{"NAME", "PORT", "ROLE", "CLUSTER"} // TODO: add status
+				headers = &[]string{"NAME", "ROLE", "CLUSTER"} // TODO: add status
 			}
 
 			util.PrintNodes(existingNodes, registryListFlags.output,
 				headers, util.NodePrinterFunc(func(tabwriter *tabwriter.Writer, node *k3d.Node) {
 					cluster := "*"
-					if _, ok := node.Labels[k3d.LabelClusterName]); ok {
-						cluster = node.Labels[k3d.LabelClusterName])
+					if _, ok := node.Labels[k3d.LabelClusterName]; ok {
+						cluster = node.Labels[k3d.LabelClusterName]
 					}
 					fmt.Fprintf(tabwriter, "%s\t%s\t%s\n",
 						strings.TrimPrefix(node.Name, "/"),
 						string(node.Role),
-						cluster
-				}))
+						cluster,
+					)
+				}),
+			)
 		},
 	}
 

--- a/cmd/registry/registryList.go
+++ b/cmd/registry/registryList.go
@@ -87,10 +87,14 @@ func NewCmdRegistryList() *cobra.Command {
 
 			util.PrintNodes(existingNodes, registryListFlags.output,
 				headers, util.NodePrinterFunc(func(tabwriter *tabwriter.Writer, node *k3d.Node) {
+					cluster := "*"
+					if _, ok := node.Labels[k3d.LabelClusterName]); ok {
+						cluster = node.Labels[k3d.LabelClusterName])
+					}
 					fmt.Fprintf(tabwriter, "%s\t%s\t%s\n",
 						strings.TrimPrefix(node.Name, "/"),
 						string(node.Role),
-						node.Labels[k3d.LabelClusterName])
+						cluster
 				}))
 		},
 	}

--- a/cmd/util/listings.go
+++ b/cmd/util/listings.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2020 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/liggitt/tabwriter"
+	k3d "github.com/rancher/k3d/v4/pkg/types"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type NodePrinter interface {
+	Print(*tabwriter.Writer, *k3d.Node)
+}
+
+type NodePrinterFunc func(*tabwriter.Writer, *k3d.Node)
+
+func (npf NodePrinterFunc) Print(writter *tabwriter.Writer, node *k3d.Node) {
+	npf(writter, node)
+}
+
+// PrintNodes prints a list of nodes, either as a table or as a JSON/YAML listing
+func PrintNodes(nodes []*k3d.Node, outputFormat string, headers *[]string, nodePrinter NodePrinter) {
+	outputFormat = strings.ToLower(outputFormat)
+
+	tabwriter := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)
+	defer tabwriter.Flush()
+
+	if outputFormat != "json" && outputFormat != "yaml" {
+		if headers != nil {
+			_, err := fmt.Fprintf(tabwriter, "%s\n", strings.Join(*headers, "\t"))
+			if err != nil {
+				log.Fatalln("Failed to print headers")
+			}
+		}
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Name < nodes[j].Name
+	})
+
+	if outputFormat == "json" || outputFormat == "yaml" {
+		var b []byte
+		var err error
+
+		switch outputFormat {
+		case "json":
+			b, err = json.Marshal(nodes)
+		case "yaml":
+			b, err = yaml.Marshal(nodes)
+		}
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Println(string(b))
+	} else {
+		for _, node := range nodes {
+			if !(outputFormat == "json" || outputFormat == "yaml") {
+				nodePrinter.Print(tabwriter, node)
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Function for listing nodes in a flexible way, used by the registries and nodes listing commands.
* New `--output=json/yaml` for printing theses listings as YAML/JSON.
