### PR TITLE
[Fix] registry: adjustments on how the registry is perceived

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -195,7 +195,7 @@ func ClusterPrep(ctx context.Context, runtime k3drt.Runtime, clusterConfig *conf
 		}
 
 		// generate the LocalRegistryHosting configmap
-		regCm, err := RegistryGenerateLocalRegistryHostingConfigMapYAML(ctx, clusterConfig.ClusterCreateOpts.Registries.Use)
+		regCm, err := RegistryGenerateLocalRegistryHostingConfigMapYAML(ctx, runtime, clusterConfig.ClusterCreateOpts.Registries.Use)
 		if err != nil {
 			return fmt.Errorf("Failed to generate LocalRegistryHosting configmap: %+v", err)
 		}
@@ -205,7 +205,7 @@ func ClusterPrep(ctx context.Context, runtime k3drt.Runtime, clusterConfig *conf
 			Action: actions.WriteFileAction{
 				Runtime: runtime,
 				Content: regCm,
-				Dest:    "/tmp/reg.yaml",
+				Dest:    k3d.DefaultLocalRegistryHostingConfigmapTempPath,
 			},
 		})
 
@@ -935,7 +935,7 @@ func prepCreateLocalRegistryHostingConfigMap(ctx context.Context, runtime k3drt.
 	success := false
 	for _, node := range cluster.Nodes {
 		if node.Role == k3d.AgentRole || node.Role == k3d.ServerRole {
-			err := runtime.ExecInNode(ctx, node, []string{"sh", "-c", "kubectl apply -f /tmp/reg.yaml"})
+			err := runtime.ExecInNode(ctx, node, []string{"sh", "-c", fmt.Sprintf("kubectl apply -f %s", k3d.DefaultLocalRegistryHostingConfigmapTempPath)})
 			if err == nil {
 				success = true
 				break

--- a/pkg/client/registry_test.go
+++ b/pkg/client/registry_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/rancher/k3d/v4/pkg/runtimes"
 	k3d "github.com/rancher/k3d/v4/pkg/types"
 )
 
@@ -54,7 +55,7 @@ data:
 
 	regs := []*k3d.Registry{reg}
 
-	cm, err := RegistryGenerateLocalRegistryHostingConfigMapYAML(context.Background(), regs)
+	cm, err := RegistryGenerateLocalRegistryHostingConfigMapYAML(context.Background(), runtimes.Docker, regs)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -358,6 +358,8 @@ const (
 	DefaultRegistriesFilePath = "/etc/rancher/k3s/registries.yaml"
 	DefaultRegistryMountPath  = "/var/lib/registry"
 	DefaultDockerHubAddress   = "registry-1.docker.io"
+	// Default temporary path for the LocalRegistryHosting configmap, from where it will be applied via kubectl
+	DefaultLocalRegistryHostingConfigmapTempPath = "/tmp/localRegistryHostingCM.yaml"
 )
 
 // Registry describes a k3d-managed registry


### PR DESCRIPTION
- LocalRegistryHostingConfigMap
  - use localhost or docker-machine as external host IP
  - fromContainerRuntime: user container-name + internal port
- registries.yaml: set up mirrors for both external and internal address

Fixes #449 