### PR TITLE
[Fix] Properly restart clusters with more than one server (sequential ordered start)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,6 +107,8 @@ steps:
 
   - name: docker_build_push_dind
     image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: "1"
     settings:
       repo: rancher/k3d
       tags:
@@ -130,6 +132,8 @@ steps:
         - tag
 
   - name: docker_build_push_binary
+    environment:
+      DOCKER_BUILDKIT: "1"
     image: plugins/docker
     settings:
       repo: rancher/k3d

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ steps:
     commands:
       - apk add git bash curl sudo jq make
       - sleep 5  # give docker enough time to start
-      - make e2e
+      - make e2e -e E2E_EXTRA=true # E2E_EXTRA=true enables tests with multiple k3s versions
     when:
       event:
         - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
         - tag
 
   - name: test
-    image: docker:19.03
+    image: docker:20.10
     volumes:
       - name: dockersock
         path: /var/run
@@ -156,7 +156,7 @@ steps:
 services:
   # Starting the docker service to be used by dind
   - name: docker
-    image: docker:19.03-dind
+    image: docker:20.10-dind
     privileged: true
     volumes:
       - name: dockersock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   - `options.k3d.noRollback` -> `options.k3d.disableRollback`
   - `options.k3d.prepDisableHostIPInjection` -> `options.k3d.disableHostIPInjection`
 - Support docker over SSH (#324, @ekristen & @inercia)
+- add root flag `--timestamps` to enable timestamped logs
+- improved multi-server cluster support (#467)
+  - log a warning, if one tries to create a cluster with only 2 nodes (no majority possible, no fault tolerance)
+  - revamped cluster start procedure: init-node, sorted servers, agents, helpers
+  - different log messages per role and start-place (that we wait for to consider a node to be ready)
+  - module: `NodeStartOpts` now accept a `ReadyLogMessage` and `NodeState` now takes a `Started` timestamp string
 
 ### Fixes
 
@@ -35,7 +41,23 @@
 ### Misc
 
 - tests/e2e: add config override test
-- add <https://github.com/AbsaOSS/k3d-action> (GitHub Action) as a related project (#476, @kuritka)
+- tests/e2e: add multi server start-stop cycle test
+- tests/e2e: improved logs with stage and test details.
+- ci/drone+tests/e2e: use E2E_EXTRA=true to always test multiple k3s versions in CI
+- builds&tests: use Docker 20.10 and BuildKit everywhere
+- docs: add <https://github.com/AbsaOSS/k3d-action> (GitHub Action) as a related project (#476, @kuritka)
+
+### Tested with
+
+- E2E Tests ran with k3s versions
+  - v1.17.17-k3s1 (see Known Issues below)
+  - v1.18.15-k3s1 (see Known Issues below)
+  - v1.19.7-k3s1
+  - v1.20.2-k3s1
+
+### Known Issues
+
+- automatic multi-server cluster restarts tend to fail with k3s versions v1.17.x & v1.18.x and probably earlier versions (using dqlite)
 
 ## v4.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . .
 RUN make build -e GIT_TAG_OVERRIDE=${GIT_TAG_OVERRIDE} && bin/k3d version
 
-FROM docker:19.03-dind as dind
+FROM docker:20.10-dind as dind
 RUN apk update && apk add bash curl sudo jq git make netcat-openbsd
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \

--- a/Makefile
+++ b/Makefile
@@ -124,14 +124,14 @@ build-cross:
 # build a specific docker target ( '%' matches the target as specified in the Dockerfile)
 build-docker-%:
 	@echo "Building Docker image k3d:$(K3D_IMAGE_TAG)-$*"
-	docker build . -t k3d:$(K3D_IMAGE_TAG)-$* --target $*
+	DOCKER_BUILDKIT=1 docker build . -t k3d:$(K3D_IMAGE_TAG)-$* --target $*
 
 # build helper images
 build-helper-images:
 	@echo "Building docker image rancher/k3d-proxy:$(GIT_TAG)"
-	docker build proxy/ -f proxy/Dockerfile -t rancher/k3d-proxy:$(GIT_TAG)
+	DOCKER_BUILDKIT=1 docker build proxy/ -f proxy/Dockerfile -t rancher/k3d-proxy:$(GIT_TAG)
 	@echo "Building docker image rancher/k3d-tools:$(GIT_TAG)"
-	docker build --no-cache tools/ -f tools/Dockerfile -t rancher/k3d-tools:$(GIT_TAG) --build-arg GIT_TAG=$(GIT_TAG)
+	DOCKER_BUILDKIT=1 docker build --no-cache tools/ -f tools/Dockerfile -t rancher/k3d-tools:$(GIT_TAG) --build-arg GIT_TAG=$(GIT_TAG)
 
 ##############################
 ########## Cleaning ##########

--- a/cmd/node/nodeCreate.go
+++ b/cmd/node/nodeCreate.go
@@ -50,7 +50,7 @@ func NewCmdNodeCreate() *cobra.Command {
 			nodes, cluster := parseCreateNodeCmd(cmd, args)
 			if err := k3dc.NodeAddToClusterMulti(cmd.Context(), runtimes.SelectedRuntime, nodes, cluster, createNodeOpts); err != nil {
 				log.Errorf("Failed to add nodes to cluster '%s'", cluster.Name)
-				log.Errorln(err)
+				log.Fatalln(err)
 			}
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,9 +46,10 @@ import (
 
 // RootFlags describes a struct that holds flags that can be set on root level of the command
 type RootFlags struct {
-	debugLogging bool
-	traceLogging bool
-	version      bool
+	debugLogging       bool
+	traceLogging       bool
+	timestampedLogging bool
+	version            bool
 }
 
 var flags = RootFlags{}
@@ -97,6 +98,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&flags.debugLogging, "verbose", false, "Enable verbose output (debug logging)")
 	rootCmd.PersistentFlags().BoolVar(&flags.traceLogging, "trace", false, "Enable super verbose output (trace logging)")
+	rootCmd.PersistentFlags().BoolVar(&flags.timestampedLogging, "timestamps", false, "Enable Log timestamps")
 
 	// add local flags
 	rootCmd.Flags().BoolVar(&flags.version, "version", false, "Show k3d and default k3s version")
@@ -161,9 +163,17 @@ func initLogging() {
 			log.TraceLevel,
 		},
 	})
-	log.SetFormatter(&log.TextFormatter{
+
+	formatter := &log.TextFormatter{
 		ForceColors: true,
-	})
+	}
+
+	if flags.timestampedLogging || os.Getenv("LOG_TIMESTAMPS") != "" {
+		formatter.FullTimestamp = true
+	}
+
+	log.SetFormatter(formatter)
+
 }
 
 func initRuntime() {

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -482,6 +482,11 @@ ClusterCreatOpts:
 		}
 	}
 
+	// WARN, if there are exactly two server nodes: that means we're using etcd, but don't have fault tolerance
+	if serverCount == 2 {
+		log.Warnln("You're creating 2 server nodes: Please consider creating at least 3 to achieve quorum & fault tolerance")
+	}
+
 	/*
 	 * Auxiliary Containers
 	 */

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -827,16 +827,17 @@ func ClusterStart(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clust
 		}
 	}
 
-	log.Infoln("Servers before sort:")
+	// TODO: remove trace logs below
+	log.Traceln("Servers before sort:")
 	for i, n := range servers {
-		log.Infof("Server %d - %s", i, n.Name)
+		log.Tracef("Server %d - %s", i, n.Name)
 	}
 	sort.Slice(servers, func(i, j int) bool {
 		return servers[i].Name < servers[j].Name
 	})
-	log.Infoln("Servers after sort:")
+	log.Traceln("Servers after sort:")
 	for i, n := range servers {
-		log.Infof("Server %d - %s", i, n.Name)
+		log.Tracef("Server %d - %s", i, n.Name)
 	}
 
 	/*

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -427,6 +427,13 @@ func NodeWaitForLogMessage(ctx context.Context, runtime runtimes.Runtime, node *
 	for {
 		select {
 		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				d, ok := ctx.Deadline()
+				if ok {
+					log.Debugf("NodeWaitForLogMessage: Context Deadline (%s) > Current Time (%s)", d, time.Now())
+				}
+				return fmt.Errorf("Context deadline exceeded while waiting for log message '%s' of node %s", message, node.Name)
+			}
 			return ctx.Err()
 		default:
 		}

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -265,6 +265,14 @@ func NodeStart(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, no
 		return err
 	}
 
+	if node.State.Started != "" {
+		ts, err := time.Parse("2006-01-02T15:04:05.999999999Z", node.State.Started)
+		if err != nil {
+			log.Debugf("Failed to parse '%s.State.Started' timestamp '%s', falling back to calulated time", node.Name, node.State.Started)
+		}
+		startTime = ts
+	}
+
 	if nodeStartOpts.Wait {
 		if nodeStartOpts.ReadyLogMessage == "" {
 			nodeStartOpts.ReadyLogMessage = k3d.ReadyLogMessageByRole[node.Role]

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -244,6 +244,9 @@ func NodeStart(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, no
 		return nil
 	}
 
+	startTime := time.Now()
+	log.Debugf("Node %s Start Time: %+v", node.Name, startTime)
+
 	// execute lifecycle hook actions
 	for _, hook := range nodeStartOpts.NodeHooks {
 		if hook.Stage == k3d.LifecycleStagePreStart {
@@ -257,7 +260,6 @@ func NodeStart(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, no
 	// start the node
 	log.Tracef("Starting node '%s'", node.Name)
 
-	startTime := time.Now()
 	if err := runtime.StartNode(ctx, node); err != nil {
 		log.Errorf("Failed to start node '%s'", node.Name)
 		return err

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -161,8 +161,7 @@ func getNodeContainer(ctx context.Context, node *k3d.Node) (*types.Container, er
 		All:     true,
 	})
 	if err != nil {
-		log.Errorln("Failed to list containers")
-		return nil, err
+		return nil, fmt.Errorf("Failed to list containers: %+v", err)
 	}
 
 	if len(containers) > 1 {

--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -373,8 +373,7 @@ func executeInNode(ctx context.Context, node *k3d.Node, cmd []string) (*types.Hi
 		Cmd:          cmd,
 	})
 	if err != nil {
-		log.Errorf("Failed to create exec config for node '%s'", node.Name)
-		return nil, err
+		return nil, fmt.Errorf("Failed to create exec config for node '%s': %+v", node.Name, err)
 	}
 
 	execConnection, err := docker.ContainerExecAttach(ctx, exec.ID, types.ExecStartCheck{

--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -191,8 +191,7 @@ func getContainersByLabel(ctx context.Context, labels map[string]string) ([]type
 		All:     true,
 	})
 	if err != nil {
-		log.Errorln("Failed to list containers")
-		return nil, err
+		return nil, fmt.Errorf("Failed to list containers: %+v", err)
 	}
 
 	return containers, nil

--- a/pkg/runtimes/docker/util.go
+++ b/pkg/runtimes/docker/util.go
@@ -34,8 +34,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
-	k3d "github.com/rancher/k3d/v4/pkg/types"
 	"github.com/pkg/errors"
+	k3d "github.com/rancher/k3d/v4/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -358,6 +358,7 @@ func GetDefaultObjectName(name string) string {
 type NodeState struct {
 	Running bool
 	Status  string
+	Started string
 }
 
 /*

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -224,9 +224,10 @@ type NodeCreateOpts struct {
 
 // NodeStartOpts describes a set of options one can set when (re-)starting a node
 type NodeStartOpts struct {
-	Wait      bool
-	Timeout   time.Duration
-	NodeHooks []NodeHook `yaml:"nodeHooks,omitempty" json:"nodeHooks,omitempty"`
+	Wait            bool
+	Timeout         time.Duration
+	NodeHooks       []NodeHook `yaml:"nodeHooks,omitempty" json:"nodeHooks,omitempty"`
+	ReadyLogMessage string
 }
 
 // NodeDeleteOpts describes a set of options one can set when deleting a node

--- a/tests/assets/config_test_simple.yaml
+++ b/tests/assets/config_test_simple.yaml
@@ -39,7 +39,7 @@ registries:
 options:
   k3d:
     wait: true
-    timeout: "60s"
+    timeout: "360s" # should be pretty high for multi-server clusters to allow for a proper startup routine
     disableLoadbalancer: false
     disableImageVolume: false
   k3s:

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -13,7 +13,7 @@ BLOCK='\033[1;37m'
 PATH=/usr/local/bin:$PATH
 export PATH
 
-log() { >&2 printf "${BLOCK}>>>${END} $1\n"; }
+log() { >&2 printf "$(date -u +"%Y-%m-%d %H:%M:%S %Z") [${CURRENT_STAGE:-undefined}] ${BLOCK}>>>${END} $1\n"; }
 
 info() { log "${BLU}$1${END}"; }
 highlight() { log "${MGT}$1${END}"; }

--- a/tests/dind.sh
+++ b/tests/dind.sh
@@ -22,6 +22,7 @@ k3de2e=$(docker run -d \
           -e E2E_INCLUDE="$E2E_INCLUDE" \
           -e E2E_EXCLUDE="$E2E_EXCLUDE" \
           -e E2E_EXTRA="$E2E_EXTRA" \
+          -e LOG_TIMESTAMPS="true" \
           --add-host "k3d-registrytest-registry:127.0.0.1" \
           --name "k3d-e2e-runner-$TIMESTAMP" \
           "k3d:$K3D_IMAGE_TAG")

--- a/tests/dind.sh
+++ b/tests/dind.sh
@@ -50,6 +50,7 @@ done
 if [ -z "$E2E_HELPER_IMAGE_TAG" ]; then
   docker exec --workdir /src "$k3de2e" make build-helper-images
   # execute tests
+  echo "Start time outside runner: $(date)"
   docker exec "$k3de2e" /src/tests/runner.sh
 else
   # execute tests

--- a/tests/extra_test_k3s_versions.sh
+++ b/tests/extra_test_k3s_versions.sh
@@ -3,7 +3,7 @@
 CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 [ -d "$CURR_DIR" ] || { echo "FATAL: no current dir (maybe running in zsh?)";  exit 1; }
 
-K3S_VERSIONS=("v1.17.14-k3s2" "v1.18.12-k3s1" "v1.19.2-k3s1" "v1.19.4-k3s1")
+K3S_VERSIONS=("v1.17.17-k3s1" "v1.18.15-k3s1" "v1.19.7-k3s1" "v1.20.2-k3s1")
 FAILED_TESTS=()
 
 # shellcheck source=./common.sh
@@ -25,10 +25,21 @@ for version in "${K3S_VERSIONS[@]}"; do
     FAILED_TESTS+=("full_lifecycle: $version")
   fi
 
+  $EXE cluster rm -a || failed "failed to delete clusters"
+
   K3S_IMAGE_TAG="$version" $CURR_DIR/test_multi_master.sh
   if [[ $? -eq 1 ]]; then
     FAILED_TESTS+=("multi_master: $version")
   fi
+
+  $EXE cluster rm -a || failed "failed to delete clusters"
+
+  K3S_IMAGE_TAG="$version" $CURR_DIR/test_multi_master_start_stop.sh
+  if [[ $? -eq 1 ]]; then
+    FAILED_TESTS+=("multi_master_start_stop: $version")
+  fi
+
+  $EXE cluster rm -a || failed "failed to delete clusters"
 
 done
 

--- a/tests/extra_test_k3s_versions.sh
+++ b/tests/extra_test_k3s_versions.sh
@@ -11,6 +11,8 @@ source "$CURR_DIR/common.sh"
 
 for version in "${K3S_VERSIONS[@]}"; do
 
+  export CURRENT_STAGE="Suite | k3s-versions | $version"
+
   info "Creating a cluster with k3s version $version ..."
   $EXE cluster create c1 --wait --timeout 60s --image "rancher/k3s:$version" || failed "could not create cluster with k3s version $version"
 

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -18,6 +18,8 @@ info "Preparing filesystem and environment..."
 
 mkdir -p $HOME/.kube
 
+echo "Start time inside runner: $(date)"
+
 section "BASIC TESTS"
 
 for i in $CURR_DIR/test_*.sh ; do

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -7,7 +7,9 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 : "${E2E_EXCLUDE:=""}"
 : "${E2E_EXTRA:=""}"
 
-# shellcheck source=./common.sh
+export CURRENT_STAGE="Runner"
+
+# shellcheck disable=SC1091
 source "$CURR_DIR/common.sh"
 
 #########################################################################################
@@ -16,13 +18,13 @@ source "$CURR_DIR/common.sh"
 
 info "Preparing filesystem and environment..."
 
-mkdir -p $HOME/.kube
+mkdir -p "$HOME"/.kube
 
 echo "Start time inside runner: $(date)"
 
 section "BASIC TESTS"
 
-for i in $CURR_DIR/test_*.sh ; do
+for i in "$CURR_DIR"/test_*.sh ; do
   base=$(basename "$i" .sh)
   skip=false
   included=false
@@ -64,7 +66,7 @@ done
 # Additional (extra) tests
 if [[ -n "$E2E_EXTRA" ]]; then
   section "EXTRA TESTS"
-  for i in $CURR_DIR/extra_test_*.sh ; do
+  for i in "$CURR_DIR"/extra_test_*.sh ; do
     base=$(basename "$i" .sh)
     if [[ $E2E_EXCLUDE =~ (^| )$base($| ) ]]; then
       highlight "***** Skipping $base *****"

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -6,6 +6,8 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./common.sh
 source "$CURR_DIR/common.sh"
 
+export CURRENT_STAGE="Test | basic"
+
 info "Creating two clusters..."
 $EXE cluster create c1 --wait --timeout 60s --api-port 6443 --env 'TEST_VAR=user\@pass\\@server[0]' || failed "could not create cluster c1"
 $EXE cluster create c2 --wait --timeout 60s || failed "could not create cluster c2"

--- a/tests/test_config_file.sh
+++ b/tests/test_config_file.sh
@@ -15,6 +15,8 @@ if [[ -n "$K3S_IMAGE_TAG" ]]; then
   EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
 fi
 
+export CURRENT_STAGE="Test | config-file | $K3S_IMAGE_TAG"
+
 
 clustername="ConfigTest"
 

--- a/tests/test_full_lifecycle.sh
+++ b/tests/test_full_lifecycle.sh
@@ -15,6 +15,8 @@ if [[ -n "$K3S_IMAGE_TAG" ]]; then
   EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
 fi
 
+export CURRENT_STAGE="Test | lifecycle | $K3S_IMAGE_TAG"
+
 
 clustername="lifecycletest"
 

--- a/tests/test_multi_master.sh
+++ b/tests/test_multi_master.sh
@@ -14,6 +14,8 @@ if [[ -n "$K3S_IMAGE_TAG" ]]; then
   EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
 fi
 
+export CURRENT_STAGE="Test | multi-server | $K3S_IMAGE_TAG"
+
 info "Creating cluster multiserver $EXTRA_TITLE ..."
 $EXE cluster create "multiserver" --servers 3 --api-port 6443 --wait --timeout 360s $EXTRA_FLAG || failed "could not create cluster multiserver $EXTRA_TITLE"
 info "Checking that we have access to the cluster..."

--- a/tests/test_multi_master_start_stop.sh
+++ b/tests/test_multi_master_start_stop.sh
@@ -14,6 +14,8 @@ if [[ -n "$K3S_IMAGE_TAG" ]]; then
   EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
 fi
 
+export CURRENT_STAGE="Test | multi-server-start-stop | $K3S_IMAGE_TAG"
+
 info "Creating cluster multiserver $EXTRA_TITLE ..."
 $EXE cluster create "multiserver" --servers 3 --api-port 6443 --wait --timeout 360s $EXTRA_FLAG || failed "could not create cluster multiserver $EXTRA_TITLE"
 info "Checking that we have access to the cluster..."
@@ -31,8 +33,8 @@ $EXE cluster stop "multiserver" || failed "failed to stop cluster"
 info "Waiting for a bit..."
 sleep 5
 
-info "Restarting cluster..."
-$EXE cluster start multiserver || failed "failed to restart cluster"
+info "Restarting cluster (time: $(date -u +"%Y-%m-%d %H:%M:%S %Z"))..."
+$EXE cluster start multiserver --timeout 180s || failed "failed to restart cluster (timeout 180s)"
 
 info "Sleeping for 5 seconds to give the cluster enough time to get ready..."
 sleep 5

--- a/tests/test_multi_master_start_stop.sh
+++ b/tests/test_multi_master_start_stop.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+[ -d "$CURR_DIR" ] || { echo "FATAL: no current dir (maybe running in zsh?)";  exit 1; }
+
+# shellcheck source=./common.sh
+source "$CURR_DIR/common.sh"
+
+: "${EXTRA_FLAG:=""}"
+: "${EXTRA_TITLE:=""}"
+
+if [[ -n "$K3S_IMAGE_TAG" ]]; then
+  EXTRA_FLAG="--image rancher/k3s:$K3S_IMAGE_TAG"
+  EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
+fi
+
+info "Creating cluster multiserver $EXTRA_TITLE ..."
+$EXE cluster create "multiserver" --servers 3 --api-port 6443 --wait --timeout 360s $EXTRA_FLAG || failed "could not create cluster multiserver $EXTRA_TITLE"
+info "Checking that we have access to the cluster..."
+check_clusters "multiserver" || failed "error checking cluster $EXTRA_TITLE"
+
+info "Sleeping for 5 seconds to give the cluster enough time to get ready..."
+sleep 5
+
+info "Checking that we have 3 server nodes online..."
+check_multi_node "multiserver" 3 || failed "failed to verify number of nodes $EXTRA_TITLE"
+
+info "Stopping cluster..."
+$EXE cluster stop "multiserver" || failed "failed to stop cluster"
+
+info "Waiting for a bit..."
+sleep 5
+
+info "Restarting cluster..."
+$EXE cluster start multiserver || failed "failed to restart cluster"
+
+info "Sleeping for 5 seconds to give the cluster enough time to get ready..."
+sleep 5
+
+info "Checking that we have access to the cluster..."
+check_clusters "multiserver" || failed "failed to verify that we have access to the cluster"
+
+info "Deleting cluster multiserver..."
+$EXE cluster delete "multiserver" || failed "could not delete the cluster multiserver $EXTRA_TITLE"
+
+passed "GOOD: multiserver cluster test successful $EXTRA_TITLE"
+
+exit 0
+
+

--- a/tests/test_multi_master_start_stop.sh
+++ b/tests/test_multi_master_start_stop.sh
@@ -34,7 +34,7 @@ info "Waiting for a bit..."
 sleep 5
 
 info "Restarting cluster (time: $(date -u +"%Y-%m-%d %H:%M:%S %Z"))..."
-$EXE cluster start multiserver --timeout 180s || failed "failed to restart cluster (timeout 180s)"
+$EXE cluster start multiserver --timeout 360s || failed "failed to restart cluster (timeout 360s)"
 
 info "Sleeping for 5 seconds to give the cluster enough time to get ready..."
 sleep 5

--- a/tests/test_registry.sh
+++ b/tests/test_registry.sh
@@ -15,6 +15,8 @@ if [[ -n "$K3S_IMAGE_TAG" ]]; then
   EXTRA_TITLE="(rancher/k3s:$K3S_IMAGE_TAG)"
 fi
 
+export CURRENT_STAGE="Test | registry | $K3S_IMAGE_TAG"
+
 
 clustername="registrytest"
 


### PR DESCRIPTION
This PR contains some fixes:

- Fixes #452 : caused by etcd and leader election, fixed by doing sequential ordered restart of servers
	- also adds e2e test for it
- Fixes adding nodes by resetting the new node's status to not be the same as the one it was copied from