### PR TITLE
[Fix] Reuse registry in multicluster (fixes #485,@kuritka) (#486, @kuritka)

### DIFF
--- a/pkg/runtimes/docker/network.go
+++ b/pkg/runtimes/docker/network.go
@@ -131,6 +131,12 @@ func GetGatewayIP(ctx context.Context, network string) (net.IP, error) {
 
 // ConnectNodeToNetwork connects a node to a network
 func (d Docker) ConnectNodeToNetwork(ctx context.Context, node *k3d.Node, networkName string) error {
+	// check that node was not attached to network before
+	if isAttachedToNetwork(node, networkName) {
+		log.Infof("Container '%s' is already connected to '%s'", node.Name,networkName)
+		return nil
+	}
+
 	// get container
 	container, err := getNodeContainer(ctx, node)
 	if err != nil {

--- a/pkg/runtimes/docker/util.go
+++ b/pkg/runtimes/docker/util.go
@@ -140,6 +140,7 @@ func (d Docker) WriteToNode(ctx context.Context, content []byte, dest string, no
 	return nil
 }
 
+
 // GetDockerClient returns a docker client
 func GetDockerClient() (*client.Client, error) {
 	var err error
@@ -167,4 +168,14 @@ func GetDockerClient() (*client.Client, error) {
 	}
 
 	return cli, err
+}
+
+// isAttachedToNetwork return true if node is attached to network
+func isAttachedToNetwork(node *k3d.Node, network string) bool {
+	for _, nw := range node.Networks {
+		if nw == network {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
closes #485 

Two clusters are created in `k3d-action-bridge-network`. Registry is successfully attached to both of them.

```json
 [
    {
        "Name": "k3d-action-bridge-network",
        "Id": "63f11e509c49dd2ccbc44459981c5c81f353a1840a6dd9f2a0c7374de71a9cb6",
        "Created": "2021-02-08T13:36:09.5304736Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "192.168.32.0/20",
                    "Gateway": "192.168.32.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": {
            "3a5cd4b100725ac325d3a62f7b9ef5ec6eaae912617d20e3e5e1d9da8a64c52c": {
                "Name": "k3d-test-gslb2-agent-1",
                "EndpointID": "4271a93479eba501478bbf49261096e606b0915a5843153fca03ff00c461b20d",
                "MacAddress": "02:42:c0:a8:20:09",
                "IPv4Address": "192.168.32.9/20",
                "IPv6Address": ""
            },
            "44edcf12fadba459c526c55d25bb26827d299d3bcba1ff9e7f882eec858bc823": {
                "Name": "k3d-test-gslb1-server-0",
                "EndpointID": "2f326bf88679ca425e33b73f46b6257557f7db38712d78ed12d2374a883a07e1",
                "MacAddress": "02:42:c0:a8:20:03",
                "IPv4Address": "192.168.32.3/20",
                "IPv6Address": ""
            },
            "474338d1cab3a66d6eee45c7de9b829603e81b6fcc2f1a23483f01b6920df25d": {
                "Name": "k3d-test-gslb2-agent-0",
                "EndpointID": "c543cbc9c35cd19c000721e8826d509bcefc63fc289189eb89c1eac168ac32dd",
                "MacAddress": "02:42:c0:a8:20:08",
                "IPv4Address": "192.168.32.8/20",
                "IPv6Address": ""
            },
            "61bc739d3d41dc6603b12bcd39ce10b118f2e9edda31ebc8654bf88a22b036f4": {
                "Name": "k3d-test-gslb1-agent-0",
                "EndpointID": "ce7e1ee6c9ba7137424b18829f652c8b27674106d6e04fdca817335451b225cd",
                "MacAddress": "02:42:c0:a8:20:04",
                "IPv4Address": "192.168.32.4/20",
                "IPv6Address": ""
            },
            "77aef92807ddb460df9ba4b249396269d640510153906ffe12ab049689feadd8": {
                "Name": "k3d-test-gslb1-agent-2",
                "EndpointID": "feb79ed7c7590d7d998702b462fa5b33a87b131ac1c7f2e905efef50463c3d63",
                "MacAddress": "02:42:c0:a8:20:06",
                "IPv4Address": "192.168.32.6/20",
                "IPv6Address": ""
            },
            "a5be74efd55594726bbf8788b68495c237b7923a17fe51e95392123ccc1d9df2": {
                "Name": "k3d-test-gslb1-agent-1",
                "EndpointID": "565f6641ebfc1e969c2827369c85a80fd00f64161814b5f178f4ff78c641028d",
                "MacAddress": "02:42:c0:a8:20:05",
                "IPv4Address": "192.168.32.5/20",
                "IPv6Address": ""
            },
            "be16f3ebad6d822a32449318515399d4e3a0b5e21c47ea7ac9dd3ecd7b31bfc6": {
                "Name": "k3d-local-registry",
                "EndpointID": "53b7e51c12a730538c08e20289a8dc2d3968a7d7888228ff42be6ca85c160dd3",
                "MacAddress": "02:42:c0:a8:20:02",
                "IPv4Address": "192.168.32.2/20",
                "IPv6Address": ""
            },
            "ea1588968aab14bf8b937ee4e501783dd453a59fff49c553497d94c8c3cc7cc6": {
                "Name": "k3d-test-gslb2-server-0",
                "EndpointID": "c229da19bad1ab37ebe79147df1ef5a0e0baf3388223ddca4e506cdcd39a8935",
                "MacAddress": "02:42:c0:a8:20:07",
                "IPv4Address": "192.168.32.7/20",
                "IPv6Address": ""
            },
            "fcdc383de670fa662d632e37395b9fbc87cbd926774e6b38eb0f062cc339912e": {
                "Name": "k3d-test-gslb2-agent-2",
                "EndpointID": "25e5c52e80ad6801c26b3035f5ad96edca3a0c098d90b2b5b9d9df2d2f42122e",
                "MacAddress": "02:42:c0:a8:20:0a",
                "IPv4Address": "192.168.32.10/20",
                "IPv6Address": ""
            }
        },
        "Options": {},
        "Labels": {
            "app": "k3d"
        }
    }
]

```