### PR TITLE
[Enhancement] Add status column to registry list

### DIFF
--- a/cmd/registry/registryList.go
+++ b/cmd/registry/registryList.go
@@ -82,7 +82,7 @@ func NewCmdRegistryList() *cobra.Command {
 			// print existing registries
 			headers := &[]string{}
 			if !registryListFlags.noHeader {
-				headers = &[]string{"NAME", "ROLE", "CLUSTER"} // TODO: add status
+				headers = &[]string{"NAME", "ROLE", "CLUSTER", "STATUS"}
 			}
 
 			util.PrintNodes(existingNodes, registryListFlags.output,
@@ -91,10 +91,11 @@ func NewCmdRegistryList() *cobra.Command {
 					if _, ok := node.Labels[k3d.LabelClusterName]; ok {
 						cluster = node.Labels[k3d.LabelClusterName]
 					}
-					fmt.Fprintf(tabwriter, "%s\t%s\t%s\n",
+					fmt.Fprintf(tabwriter, "%s\t%s\t%s\t%s\n",
 						strings.TrimPrefix(node.Name, "/"),
 						string(node.Role),
 						cluster,
+						node.State.Status,
 					)
 				}),
 			)


### PR DESCRIPTION
# What

Add status column to registry list:

```
NAME                  ROLE       CLUSTER
k3d-local.localhost   registry
```
:arrow_down: 
```
NAME                  ROLE       CLUSTER   STATUS
k3d-local.localhost   registry             running
```

# Why

I wanted to see the status column as I often stop the registry containers manually when I'm not using `k3d`. Also there was already a TODO comment for this.

<!-- Get recognized using our all-contributors bot: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
