### PR TITLE
[FIX] Properly handle host/hostIP cases for kubeconfig (#500, @fabricev)

### DIFF
--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -77,7 +77,6 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 		HostIP:   simpleConfig.ExposeAPI.HostIP,
 		HostPort: simpleConfig.ExposeAPI.HostPort,
 	}
-	fmt.Printf("RES2: %+v", kubeAPIExposureOpts)
 
 	// FILL CLUSTER CONFIG
 	newCluster := k3d.Cluster{

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -69,8 +69,11 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 		simpleConfig.ExposeAPI.HostIP = k3d.DefaultAPIHost
 	}
 
-	kubeAPIExposureOpts := &k3d.ExposureOpts{
-		Host: simpleConfig.ExposeAPI.Host,
+	kubeAPIExposureOpts := &k3d.ExposureOpts{}
+	if simpleConfig.ExposeAPI.Host == k3d.DefaultAPIHost {
+		kubeAPIExposureOpts.Host = simpleConfig.ExposeAPI.HostIP
+	} else {
+		kubeAPIExposureOpts.Host = simpleConfig.ExposeAPI.Host
 	}
 	kubeAPIExposureOpts.Port = k3d.DefaultAPIPort
 	kubeAPIExposureOpts.Binding = nat.PortBinding{

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -62,24 +62,22 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 	}
 
 	// -> API
-	if simpleConfig.ExposeAPI.Host == "" {
-		simpleConfig.ExposeAPI.Host = k3d.DefaultAPIHost
-	}
 	if simpleConfig.ExposeAPI.HostIP == "" {
 		simpleConfig.ExposeAPI.HostIP = k3d.DefaultAPIHost
 	}
+	if simpleConfig.ExposeAPI.Host == "" {
+		simpleConfig.ExposeAPI.Host = simpleConfig.ExposeAPI.HostIP
+	}
 
-	kubeAPIExposureOpts := &k3d.ExposureOpts{}
-	if simpleConfig.ExposeAPI.Host == k3d.DefaultAPIHost {
-		kubeAPIExposureOpts.Host = simpleConfig.ExposeAPI.HostIP
-	} else {
-		kubeAPIExposureOpts.Host = simpleConfig.ExposeAPI.Host
+	kubeAPIExposureOpts := &k3d.ExposureOpts{
+		Host: simpleConfig.ExposeAPI.Host,
 	}
 	kubeAPIExposureOpts.Port = k3d.DefaultAPIPort
 	kubeAPIExposureOpts.Binding = nat.PortBinding{
 		HostIP:   simpleConfig.ExposeAPI.HostIP,
 		HostPort: simpleConfig.ExposeAPI.HostPort,
 	}
+	fmt.Printf("RES2: %+v", kubeAPIExposureOpts)
 
 	// FILL CLUSTER CONFIG
 	newCluster := k3d.Cluster{


### PR DESCRIPTION
# What

Fixing a behavior where Host option is always used when generating kubeconfigs, even when a HostIP is provided.

# Why

#499 

# Implications

The logic of generating the kubeconfig has changed is not always based on the Host field, assume this is OK when a HostIP is specified (and no Host) to use this field for the server part of the kubeconfig.