### PR TITLE
Fix typo in cluster stop command doc (#513, @searsaw)

### DIFF
--- a/cmd/cluster/clusterStop.go
+++ b/cmd/cluster/clusterStop.go
@@ -56,7 +56,7 @@ func NewCmdClusterStop() *cobra.Command {
 	}
 
 	// add flags
-	cmd.Flags().BoolP("all", "a", false, "Start all existing clusters")
+	cmd.Flags().BoolP("all", "a", false, "Stop all existing clusters")
 
 	// add subcommands
 


### PR DESCRIPTION
I noticed the `k3d cluster stop` help has what looks like a miss when coping and pasting. So I fixed the typo.

# What

Simple typo fix in the `k3d cluster stop` help docs.

# Why

Because knowledge is power!

# Implications

The help documentation will correctly represent what the `--all` flag does.