### PR TITLE
[Feature] Runtime Info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	rt "runtime"
 
@@ -121,6 +122,23 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			printVersion()
 		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "runtime-info",
+		Short: "Show runtime information",
+		Long:  "Show some information about the runtime environment (e.g. docker info)",
+		Run: func(cmd *cobra.Command, args []string) {
+			info, err := runtimes.SelectedRuntime.Info()
+			if err != nil {
+				log.Fatalln(err)
+			}
+			err = yaml.NewEncoder(os.Stdout).Encode(info)
+			if err != nil {
+				log.Fatalln(err)
+			}
+		},
+		Hidden: true,
 	})
 
 	// Init

--- a/pkg/runtimes/docker/info.go
+++ b/pkg/runtimes/docker/info.go
@@ -1,0 +1,72 @@
+/*
+Copyright © 2020 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package docker
+
+import (
+	"context"
+	"strings"
+
+	runtimeTypes "github.com/rancher/k3d/v4/pkg/runtimes/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func (d Docker) Info() (*runtimeTypes.RuntimeInfo, error) {
+	// create docker client
+	docker, err := GetDockerClient()
+	if err != nil {
+		log.Errorln("Failed to create docker client")
+		return nil, err
+	}
+	defer docker.Close()
+
+	info, err := docker.Info(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeInfo := runtimeTypes.RuntimeInfo{
+		Name:          d.ID(),
+		Endpoint:      d.GetRuntimePath(),
+		Version:       info.ServerVersion,
+		OS:            info.OperatingSystem,
+		OSType:        info.OSType,
+		Arch:          info.Architecture,
+		CgroupVersion: info.CgroupVersion,
+		CgroupDriver:  info.CgroupDriver,
+		Filesystem:    "UNKNOWN",
+	}
+
+	// Get the backing filesystem for the storage driver
+	// This is not embedded nicely in a struct or map, so we have to do some string inspection
+	for i := range info.DriverStatus {
+		for j := range info.DriverStatus[i] {
+			if strings.Contains(info.DriverStatus[i][j], "Backing Filesystem") {
+				if len(info.DriverStatus[i]) >= j+2 {
+					runtimeInfo.Filesystem = info.DriverStatus[i][j+1]
+				}
+			}
+		}
+	}
+
+	return &runtimeInfo, nil
+}

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/rancher/k3d/v4/pkg/runtimes/docker"
+	runtimeTypes "github.com/rancher/k3d/v4/pkg/runtimes/types"
 	k3d "github.com/rancher/k3d/v4/pkg/types"
 )
 
@@ -72,6 +73,7 @@ type Runtime interface {
 	GetHostIP(context.Context, string) (net.IP, error)
 	ConnectNodeToNetwork(context.Context, *k3d.Node, string) error      // @param context, node, network name
 	DisconnectNodeFromNetwork(context.Context, *k3d.Node, string) error // @param context, node, network name
+	Info() (*runtimeTypes.RuntimeInfo, error)
 }
 
 // GetRuntime checks, if a given name is represented by an implemented k3d runtime and returns it

--- a/pkg/runtimes/types/types.go
+++ b/pkg/runtimes/types/types.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2020 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package types
+
+type RuntimeInfo struct {
+	Name          string
+	Endpoint      string `yaml:",omitempty" json:",omitempty"`
+	Version       string `yaml:",omitempty" json:",omitempty"`
+	OSType        string `yaml:",omitempty" json:",omitempty"`
+	OS            string `yaml:",omitempty" json:",omitempty"`
+	Arch          string `yaml:",omitempty" json:",omitempty"`
+	CgroupVersion string `yaml:",omitempty" json:",omitempty"`
+	CgroupDriver  string `yaml:",omitempty" json:",omitempty"`
+	Filesystem    string `yaml:",omitempty" json:",omitempty"`
+}


### PR DESCRIPTION
This PR adds the `Info()` function to the Runtime interface which populates and returns a `RuntimeInfo` struct which can be used in the future to add runtime-specific configurations (like `/dev/mapper` mounts for zfs/btrfs or cgroup version specifics, etc.).
This also adds the `k3d runtime-info` command (hidden) that can be used to gain debug information.

Example:
`$ k3d runtime-info`
```yaml
name: docker
endpoint: /var/run/docker.sock
version: 20.10.5
ostype: linux
os: Pop!_OS 20.10
arch: x86_64
cgroupversion: "1"
cgroupdriver: cgroupfs
filesystem: extfs
```