### PR TITLE
[Cleanup] Follow-Up for #638

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@
     - this also checks the config before applying it, so the lb doesn't crash on a faulty config
   - updating the loadbalancer writes the new config file and also checks if everything's going fine afterwards
 - helper images can now be set explicitly via environment variables: `K3D_IMAGE_LOADBALANCER` & `K3D_IMAGE_TOOLS` (#638)
+- concurrently add new nodes to an existing cluster (remove some dumb code) (#640)
+  - `--wait` is now the default for `k3d node create`
 
 ### Misc
 
 - tests/e2e: timeouts everywhere to avoid killing DroneCI (#638)
+- logs: really final output when creating/deleting nodes (so far, we were not outputting a final success message and the process was still doing stuff) (#640)
 
 ## v4.4.6
 

--- a/cmd/node/nodeCreate.go
+++ b/cmd/node/nodeCreate.go
@@ -55,6 +55,7 @@ func NewCmdNodeCreate() *cobra.Command {
 				log.Errorf("Failed to add nodes to cluster '%s'", cluster.Name)
 				log.Fatalln(err)
 			}
+			log.Infof("Successfully created %d node(s)!", len(nodes))
 		},
 	}
 

--- a/cmd/node/nodeCreate.go
+++ b/cmd/node/nodeCreate.go
@@ -73,7 +73,7 @@ func NewCmdNodeCreate() *cobra.Command {
 	cmd.Flags().StringP("image", "i", fmt.Sprintf("%s:%s", k3d.DefaultK3sImageRepo, version.GetK3sVersion(false)), "Specify k3s image used for the node(s)")
 	cmd.Flags().String("memory", "", "Memory limit imposed on the node [From docker]")
 
-	cmd.Flags().BoolVar(&createNodeOpts.Wait, "wait", false, "Wait for the node(s) to be ready before returning.")
+	cmd.Flags().BoolVar(&createNodeOpts.Wait, "wait", true, "Wait for the node(s) to be ready before returning.")
 	cmd.Flags().DurationVar(&createNodeOpts.Timeout, "timeout", 0*time.Second, "Maximum waiting time for '--wait' before canceling/returning.")
 
 	cmd.Flags().StringSliceP("runtime-label", "", []string{}, "Specify container runtime labels in format \"foo=bar\"")

--- a/cmd/node/nodeDelete.go
+++ b/cmd/node/nodeDelete.go
@@ -59,6 +59,7 @@ func NewCmdNodeDelete() *cobra.Command {
 						log.Fatalln(err)
 					}
 				}
+				log.Infof("Successfully deleted %d node(s)!", len(nodes))
 			}
 		},
 	}

--- a/pkg/client/loadbalancer.go
+++ b/pkg/client/loadbalancer.go
@@ -77,7 +77,6 @@ func UpdateLoadbalancerConfig(ctx context.Context, runtime runtimes.Runtime, clu
 	}
 	log.Debugf("Writing lb config:\n%s", string(newLbConfigYaml))
 	startTime := time.Now().Truncate(time.Second).UTC()
-	log.Debugf("timestamp: %s", startTime.Format("2006-01-02T15:04:05.999999999Z"))
 	if err := runtime.WriteToNode(ctx, newLbConfigYaml, k3d.DefaultLoadbalancerConfigPath, 0744, cluster.ServerLoadBalancer); err != nil {
 		return fmt.Errorf("error writing new loadbalancer config to container: %w", err)
 	}
@@ -102,6 +101,7 @@ func UpdateLoadbalancerConfig(ctx context.Context, runtime runtimes.Runtime, clu
 			return LBConfigErrFailedTest
 		}
 	}
+	log.Infof("Successfully configured loadbalancer %s!", cluster.ServerLoadBalancer.Name)
 
 	time.Sleep(1 * time.Second) // waiting for a second, to avoid issues with too fast lb updates which would screw up the log waits
 

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -207,6 +207,7 @@ func NodeAddToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 
 	// if it's a server node, then update the loadbalancer configuration
 	if node.Role == k3d.ServerRole {
+		log.Infoln("Updating loadbalancer config to include new server node(s)")
 		if err := UpdateLoadbalancerConfig(ctx, runtime, cluster); err != nil {
 			if !errors.Is(err, LBConfigErrHostNotFound) {
 				return fmt.Errorf("error updating loadbalancer: %w", err)


### PR DESCRIPTION
Copied from #638:


- [x] NodeDelete: success message at the end (i.e. also after updating the LB)
- [x] NodeCreate/NodeDelete: single collective update of the loadbalancer
	- [x] only, when nodes are up and running