### PR TITLE
[FEATURE] Expand environment variables in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   - pkg: new `Config` interface type to support new generic `FromViper` config file parsing
 - changed flags `--k3s-server-arg` & `--k3s-agent-arg` into `--k3s-arg` with nodefilter support (#605)
   - new config path `options.k3s.extraArgs`
+- config file: environment variables (`$VAR`, `${VAR}` will be expanded unconditionally) (#643)
 
 ### Misc
 

--- a/tests/assets/config_test_simple.yaml
+++ b/tests/assets/config_test_simple.yaml
@@ -8,7 +8,7 @@ kubeAPI:
   hostPort: "6446"
 image: rancher/k3s:latest
 volumes:
-  - volume: /my/path:/some/path
+  - volume: $HOME:/some/path
     nodeFilters:
       - all
 ports:


### PR DESCRIPTION
E.g. `$HOME` -> `/home/iwilltry42`
This is done unconditionally/unchecked and even before viper reads in the config and before the file gets validated using the JSONSchema.
That way, we don't have to include much logic and the user has the most freedom possible here.

Fixes #537 