### PR TITLE
[Enhancement] Follow Docker's image nameing convention in `k3d image import` (#653, @cimnine)

### DIFF
--- a/cmd/image/imageImport.go
+++ b/cmd/image/imageImport.go
@@ -48,6 +48,9 @@ func NewCmdImageImport() *cobra.Command {
 If an IMAGE starts with the prefix 'docker.io/', then this prefix is stripped internally.
 That is, 'docker.io/rancher/k3d-tools:latest' is treated as 'rancher/k3d-tools:latest'.
 
+If an IMAGE starts with the prefix 'library/' (or 'docker.io/library/'), then this prefix is stripped internally.
+That is, 'library/busybox:latest' (or 'docker.io/library/busybox:latest') are treated as 'busybox:latest'.
+
 If an IMAGE does not have a version tag, then ':latest' is assumed.
 That is, 'rancher/k3d-tools' is treated as 'rancher/k3d-tools:latest'.
 

--- a/cmd/image/imageImport.go
+++ b/cmd/image/imageImport.go
@@ -41,9 +41,18 @@ func NewCmdImageImport() *cobra.Command {
 
 	// create new command
 	cmd := &cobra.Command{
-		Use:     "import [IMAGE | ARCHIVE [IMAGE | ARCHIVE...]]",
-		Short:   "Import image(s) from docker into k3d cluster(s).",
-		Long:    `Import image(s) from docker into k3d cluster(s).`,
+		Use:   "import [IMAGE | ARCHIVE [IMAGE | ARCHIVE...]]",
+		Short: "Import image(s) from docker into k3d cluster(s).",
+		Long: `Import image(s) from docker into k3d cluster(s).
+
+If an IMAGE starts with the prefix 'docker.io/', then this prefix is stripped internally.
+That is, 'docker.io/rancher/k3d-tools:latest' is treated as 'rancher/k3d-tools:latest'.
+
+If an IMAGE does not have a version tag, then ':latest' is assumed.
+That is, 'rancher/k3d-tools' is treated as 'rancher/k3d-tools:latest'.
+
+A file ARCHIVE always takes precedence.
+So if a file './rancher/k3d-tools' exists, k3d will try to import it instead of the IMAGE of the same name.`,
 		Aliases: []string{"images"},
 		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/docs/usage/commands/k3d_image_import.md
+++ b/docs/usage/commands/k3d_image_import.md
@@ -6,6 +6,15 @@ Import image(s) from docker into k3d cluster(s).
 
 Import image(s) from docker into k3d cluster(s).
 
+If an IMAGE starts with the prefix 'docker.io/', then this prefix is stripped internally.
+That is, 'docker.io/rancher/k3d-tools:latest' is treated as 'rancher/k3d-tools:latest'.
+
+If an IMAGE does not have a version tag, then ':latest' is assumed.
+That is, 'rancher/k3d-tools' is treated as 'rancher/k3d-tools:latest'.
+
+A file ARCHIVE always takes precedence.
+So if a file './rancher/k3d-tools' exists, k3d will try to import it instead of the IMAGE of the same name.
+
 ```
 k3d image import [IMAGE | ARCHIVE [IMAGE | ARCHIVE...]] [flags]
 ```

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -54,12 +54,20 @@ func ImageImportIntoClusterMulti(ctx context.Context, runtime runtimes.Runtime, 
 		found := false
 		// Check if the current element is a file
 		if _, err := os.Stat(image); os.IsNotExist(err) {
+			// `runtimeImages` are returned without the 'docker.io/' prefix. So if `image` has such a prefix, we shall drop it.
+			localImageName := strings.TrimPrefix(image, "docker.io/")
+
+			// `runtimeImages` always contain a `:versionName` part. So if `image` doesn't, we shall add the default tag `:latest`.
+			if !strings.Contains(image, ":") {
+				localImageName = fmt.Sprintf("%s:latest", localImageName)
+			}
+
 			// not a file? Check if such an image is present in the container runtime
 			for _, runtimeImage := range runtimeImages {
-				if image == runtimeImage {
+				if localImageName == runtimeImage {
 					found = true
-					imagesFromRuntime = append(imagesFromRuntime, image)
-					log.Debugf("Selected image '%s' found in runtime", image)
+					imagesFromRuntime = append(imagesFromRuntime, runtimeImage)
+					log.Debugf("Selected image '%s' (found as '%s') in runtime", image, runtimeImage)
 					break
 				}
 			}

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright © 2021 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package tools
+
+import (
+	"testing"
+)
+
+func Test_findRuntimeImage(T *testing.T) {
+	imageRegistry := []string{
+		"busybox:latest",
+		"busybox:version",
+		"registry/one:version",
+		"registry/one:latest",
+		"registry/one/two:version",
+		"registry/one/two:latest",
+		"registry/one/two/three/four:version",
+		"registry/one/two/three/four:latest",
+		"registry:1234/one:version",
+		"registry:1234/one:latest",
+		"registry:1234/one/two:version",
+		"registry:1234/one/two:latest",
+		"registry:1234/one/two/three/four:version",
+		"registry:1234/one/two/three/four:latest",
+	}
+
+	tests := map[string]struct {
+		expectedImageName       string
+		expectedFound           bool
+		givenRequestedImageName string
+	}{
+		"registry image tag": {
+			expectedImageName:       "registry/one/two:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one/two",
+		},
+		"registry image tag with version": {
+			expectedImageName:       "registry/one/two:version",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one/two:version",
+		},
+		"registry image tag with short path": {
+			expectedImageName:       "registry/one:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one",
+		},
+		"registry image tag with short path and specific version": {
+			expectedImageName:       "registry/one:version",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one:version",
+		},
+		"registry image tag with short path and registry port": {
+			expectedImageName:       "registry:1234/one:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "registry:1234/one",
+		},
+		"registry image tag with short path and specific version, registry port": {
+			expectedImageName:       "registry:1234/one:version",
+			expectedFound:           true,
+			givenRequestedImageName: "registry:1234/one:version",
+		},
+		"registry image tag with long path": {
+			expectedImageName:       "registry/one/two/three/four:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one/two/three/four",
+		},
+		"registry image tag with long path and specific version": {
+			expectedImageName:       "registry/one/two/three/four:version",
+			expectedFound:           true,
+			givenRequestedImageName: "registry/one/two/three/four:version",
+		},
+		"registry image tag with long path and repository port": {
+			expectedImageName:       "registry:1234/one/two/three/four:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "registry:1234/one/two/three/four",
+		},
+		"registry image tag with long path, specific version and repository port": {
+			expectedImageName:       "registry:1234/one/two/three/four:version",
+			expectedFound:           true,
+			givenRequestedImageName: "registry:1234/one/two/three/four:version",
+		},
+		"plain library image tag": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "busybox",
+		},
+		"plain library image tag with version": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "busybox:latest",
+		},
+		"library image tag": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "library/busybox",
+		},
+		"library image tag with latest version": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "library/busybox:latest",
+		},
+		"library image tag with specific version": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "library/busybox:latest",
+		},
+		"library image tag with repository": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "docker.io/library/busybox",
+		},
+		"library image tag with repository and latest version": {
+			expectedImageName:       "busybox:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "docker.io/library/busybox:latest",
+		},
+		"library image tag with repository and specific version": {
+			expectedImageName:       "busybox:version",
+			expectedFound:           true,
+			givenRequestedImageName: "docker.io/library/busybox:version",
+		},
+		"unknown image": {
+			expectedFound:           false,
+			givenRequestedImageName: "unknown",
+		},
+		"unknown with version": {
+			expectedFound:           false,
+			givenRequestedImageName: "unknown:latest",
+		},
+		"unknown with repository": {
+			expectedFound:           false,
+			givenRequestedImageName: "docker.io/unknown",
+		},
+		"unknown with repository and version": {
+			expectedFound:           false,
+			givenRequestedImageName: "docker.io/unknown:tag",
+		},
+	}
+
+	for name, tt := range tests {
+		T.Run(name, func(t *testing.T) {
+			actualImageName, actualFound := findRuntimeImage(tt.givenRequestedImageName, imageRegistry)
+
+			if tt.expectedFound != actualFound {
+				t.Errorf("The image '%s' should not have been found.", tt.givenRequestedImageName)
+			}
+			if tt.expectedImageName != actualImageName {
+				t.Errorf("The image '%s' was found, but '%s' was expected.", actualImageName, tt.expectedImageName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What

Once upon a time, all Docker images were stored either locally or on Docker Hub. They were called `repoName/imageName:versionName` and all was well.

Then people started to build other registries. Eventually it was decided that the registry will just be prefixed to the image name: `registry-name.example/repoName/imageName:versionName`. But to maintain compatibility, images without a registry prefix were still fetched from Docker Hub, the default registry.

The Docker Hub registry eventually was named `docker.io` and images that were tagged `docker.io/repoName/imageName:versionName` were equivalent to images tagged as `repoName/imageName:versionName`.

Probably on a different occasion and for different reaons, `latest` would be assumed by Docker if no `versionName` part was given.

These two conventions are what this PR adds to k3d for the `image import` command.
* That images tagged as `docker.io/repoName/imageName:versionName` can be imported to a cluster, i.e. that `k3d image import  'docker.io/repoName/imageName:versionName'` just works. Because currently it fails, whereas `k3d image import 'repoName/imageName:versionName'` does not. And neither does `k3d image import 'any-other.registry/repoName/imageName:versionName'`.
* That images without a `:versionName` have `:latest` added automatically.

(Side Note: The story about how `docker.io` came to be the default registry prefix is most probably not historically accurate. If it were, it would be so by pure luck.)

# Why

It is not immediately obvious for the user – and neither is it documented – that k3d is more strict regarding to how it treats image tags than Docker is.
It's especially confusing if an image was previously built locally with `docker build -t 'docker.io/repoName/imageName:tagName'`, but the same image can later not be imported by that same name.

# Implications

I'm not aware of any obvious implications. It allows behaviour that IMO could be expected but that is currently resulting in an error.

I would not consider this change to be a breaking change.
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
