### PR TITLE
[ENHANCEMENT] imageImport: start existing tools node before using it and add option to keep it around

### DIFF
--- a/cmd/image/imageImport.go
+++ b/cmd/image/imageImport.go
@@ -86,6 +86,7 @@ So if a file './rancher/k3d-tools' exists, k3d will try to import it instead of 
 	}
 
 	cmd.Flags().BoolVarP(&loadImageOpts.KeepTar, "keep-tarball", "k", false, "Do not delete the tarball containing the saved images from the shared volume")
+	cmd.Flags().BoolVarP(&loadImageOpts.KeepToolsNode, "keep-tools", "t", false, "Do not delete the tools node after import")
 
 	/* Subcommands */
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -253,7 +253,8 @@ type NodeHookAction interface {
 
 // ImageImportOpts describes a set of options one can set for loading image(s) into cluster(s)
 type ImageImportOpts struct {
-	KeepTar bool
+	KeepTar       bool
+	KeepToolsNode bool
 }
 
 type IPAM struct {


### PR DESCRIPTION
Title says it all..

- if there's a tools node container, but it's not running start it, then re-use it
- new `k3d image import [-t | --keep-tools]` flag to not delete the tools node after importing the image (so it can be re-used in the next round of imports)

Potentially fixes #671