### PR TITLE
Add darwin-arm64 to supported install.sh archs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="darwin-386\ndarwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nwindows-386\nwindows-amd64"
+  local supported="darwin-386\ndarwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nwindows-386\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to $REPO_URL"


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What

Fixes macOS on M1 execution of `./install.sh`

# Why

```zsh
curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
No prebuilt binary for darwin-arm64.
To build from source, go to https://github.com/rancher/k3d
Failed to install k3d
	For support, go to https://github.com/rancher/k3d.
```

# Implications

Does not affect existing functionality of actual CLI