### PR TITLE
[Enhancement] Create workers/helpers concurrently

### DIFF
--- a/docgen/main.go
+++ b/docgen/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/rancher/k3d/v4/cmd"
 	"github.com/spf13/cobra/doc"

--- a/tools/cmd/image.go
+++ b/tools/cmd/image.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/client"
 )

--- a/tools/main.go
+++ b/tools/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	run "github.com/rancher/k3d/tools/cmd"
 	"github.com/rancher/k3d/tools/version"


### PR DESCRIPTION
## Test

### Before

- Branch: `main-v5`
- Commit: `60738205`
- Time: `k3d cluster create testspeed -s 3 -a 3  0.87s user 0.54s system 1% cpu 1:23.85 total`

### After

- Branch: `enhancement/concurrent-worker-creation`
- Commit: `9d63c3b3`
- Time: `k3d cluster create testspeed -s 3 -a 3  1.24s user 0.42s system 2% cpu 1:03.23 total`

... resulting in a 20 seconds improvement in overall cluster creation time

### Note

This didn't use a super clean test setup, so don't take the "result" 100% for granted.

Fixes #673 