### PR TITLE
[Fix] Drone CI: push second multiarch manifest for `latest` tag on k3d-tools and k3d-proxy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -354,6 +354,23 @@ steps:
       event:
         - tag
 
+  - name: push_manifest_latest
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/k3d-proxy:latest"
+      template: "rancher/k3d-proxy:latest-OS-ARCH"
+      platforms:
+        - linux/amd64
+        - linux/arm
+        - linux/arm64
+    when:
+      event:
+        - tag
+
 trigger:
   event:
     - tag
@@ -490,6 +507,23 @@ steps:
         from_secret: docker_password
       target: "rancher/k3d-tools:${DRONE_TAG}"
       template: "rancher/k3d-tools:${DRONE_TAG}-OS-ARCH"
+      platforms:
+        - linux/amd64
+        - linux/arm
+        - linux/arm64
+    when:
+      event:
+        - tag
+
+  - name: push_manifest_latest
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/k3d-tools:latest"
+      template: "rancher/k3d-tools:latest-OS-ARCH"
       platforms:
         - linux/amd64
         - linux/arm


### PR DESCRIPTION
Fixes #694 

Apparently, the `latest` tag on `rancher/k3d-proxy` and `rancher/k3d-tools` wasn't updated in over a year since we switched to multiarch builds in https://github.com/rancher/k3d/commit/724b7746ee2a6af812df832b953030a7c5c8ea52 .
This PR aims to bring the `latest` tag back.
However, with how the change is currently, it would set the `latest` tag even on preview/beta/dev releases.. do we really want this? :thinking: 
It's how it is right now with arch specific builds tagged like `latest-OS-ARCH`, e.g. `latest-linux-amd64`.