### PR TITLE
[Enhancement] Improved Pipeline for Multiarch Images and SemVer Tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -354,6 +354,23 @@ steps:
       event:
         - tag
 
+  - name: push_manifest_latest
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/k3d-proxy:latest"
+      template: "rancher/k3d-proxy:latest-OS-ARCH"
+      platforms:
+        - linux/amd64
+        - linux/arm
+        - linux/arm64
+    when:
+      event:
+        - tag
+
 trigger:
   event:
     - tag
@@ -490,6 +507,23 @@ steps:
         from_secret: docker_password
       target: "rancher/k3d-tools:${DRONE_TAG}"
       template: "rancher/k3d-tools:${DRONE_TAG}-OS-ARCH"
+      platforms:
+        - linux/amd64
+        - linux/arm
+        - linux/arm64
+    when:
+      event:
+        - tag
+
+  - name: push_manifest_latest
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/k3d-tools:latest"
+      template: "rancher/k3d-tools:latest-OS-ARCH"
       platforms:
         - linux/amd64
         - linux/arm

--- a/.drone.yml
+++ b/.drone.yml
@@ -103,58 +103,6 @@ steps:
           - "refs/tags/*test*"
           - "refs/tags/*dev*"
 
-  - name: docker_build_push_dind
-    image: plugins/docker
-    environment:
-      DOCKER_BUILDKIT: "1"
-    settings:
-      repo: rancher/k3d
-      tags:
-        - latest-dind
-        - "${DRONE_TAG}-dind"
-      dockerfile: Dockerfile
-      target: dind
-      context: .
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      build_args:
-        - GIT_TAG_OVERRIDE=${DRONE_TAG}
-    depends_on:
-      - lint
-      - test
-      - build
-    when:
-      event:
-        - tag
-
-  - name: docker_build_push_binary
-    environment:
-      DOCKER_BUILDKIT: "1"
-    image: plugins/docker
-    settings:
-      repo: rancher/k3d
-      tags:
-        - latest
-        - "${DRONE_TAG}"
-      dockerfile: Dockerfile
-      target: binary-only
-      context: .
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      build_args:
-        - GIT_TAG_OVERRIDE=${DRONE_TAG}
-    depends_on:
-      - lint
-      - test
-      - build
-    when:
-      event:
-        - tag
-
 services:
   # Starting the docker service to be used by dind
   - name: docker
@@ -215,61 +163,163 @@ trigger:
     - main
 
 ---
-#####################
-##### k3d-proxy #####
-#####################
+###########################
+###### Docker Images ######
+###########################
+#
+# +++ Docker Images +++
+# Tagged using the auto_tag feature of the docker plugin
+# See http://plugins.drone.io/drone-plugins/drone-docker/#autotag
+# > if event type is `tag`
+# > > 1.0.0 produces docker tags 1, 1.0, 1.0.0
+# > > 1.0.0-rc.1 produces docker tags 1.0.0-rc.1
+# > if event type is `push` and target branch == default branch (main)
+# > > tag `latest`
+
+
+################################
+##### Docker Images: amd64 #####
+################################
 
 kind: pipeline
 type: docker
-name: proxy_linux_amd64
+name: linux_amd64
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-  - name: build_push
+
+  - name: build_push_binary
+    environment:
+      DOCKER_BUILDKIT: "1"
+    image: plugins/docker
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
+      dockerfile: Dockerfile
+      target: binary-only
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+
+  - name: build_push_dind
+    image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: "1"
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
+      dockerfile: Dockerfile
+      target: dind
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+        - ARCH=amd64
+
+  - name: build_push_proxy
     image: plugins/docker
     settings:
       repo: rancher/k3d-proxy
-      tags:
-        - latest-linux-amd64
-        - "${DRONE_TAG}-linux-amd64"
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
       dockerfile: proxy/Dockerfile
       context: proxy/
       username:
         from_secret: docker_username
       password:
         from_secret: docker_password
-    when:
-      event:
-        - tag
+
+  - name: build_push_tools
+    image: plugins/docker
+    settings:
+      repo: rancher/k3d-tools
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
+      dockerfile: tools/Dockerfile
+      context: tools/
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 
 trigger:
   event:
-    - tag
+    - tag # see note at the start of the "Docker Images" section: creates SemVer tagged images using the `auto_tag` option of the docker plugin
+    - push # `auto_tag` option only creates the `latest` tag if target branch is default branch (i.e. `main`)
 
 depends_on:
   - main
 
 ---
 
+################################
+##### Docker Images: arm #####
+################################
+
 kind: pipeline
 type: docker
-name: proxy_linux_arm
+name: linux_arm
 
 platform:
   os: linux
   arch: arm
 
 steps:
-  - name: build_push
+  - name: build_push_binary
+    environment:
+      DOCKER_BUILDKIT: "1"
+    image: plugins/docker
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-arm
+      dockerfile: Dockerfile
+      target: binary-only
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+
+  - name: build_push_dind
+    image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: "1"
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      dockerfile: Dockerfile
+      target: dind
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+        - ARCH=arm
+
+  - name: build_push_proxy
     image: plugins/docker
     settings:
       repo: rancher/k3d-proxy
-      tags:
-        - latest-linux-arm
-        - "${DRONE_TAG}-linux-arm"
+      auto_tag: true
+      auto_tag_suffix: linux-arm
       dockerfile: proxy/Dockerfile
       context: proxy/
       username:
@@ -278,35 +328,87 @@ steps:
         from_secret: docker_password
       build_args:
         - ARCH=arm
-    when:
-      event:
-        - tag
+
+  - name: build_push_tools
+    image: plugins/docker
+    settings:
+      repo: rancher/k3d-tools
+      auto_tag: true
+      auto_tag_suffix: linux-arm
+      dockerfile: tools/Dockerfile
+      context: tools/
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 
 trigger:
   event:
-    - tag
+    - tag # see note at the start of the "Docker Images" section: creates SemVer tagged images using the `auto_tag` option of the docker plugin
+    - push # `auto_tag` option only creates the `latest` tag if target branch is default branch (i.e. `main`)
 
 depends_on:
   - main
 
 ---
 
+################################
+##### Docker Images: arm64 #####
+################################
+
 kind: pipeline
 type: docker
-name: proxy_linux_arm64
+name: linux_arm64
 
 platform:
   os: linux
   arch: arm64
 
 steps:
-  - name: build_push
+
+  - name: build_push_binary
+    environment:
+      DOCKER_BUILDKIT: "1"
+    image: plugins/docker
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      dockerfile: Dockerfile
+      target: binary-only
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+
+  - name: build_push_dind
+    image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: "1"
+    settings:
+      repo: rancher/k3d
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      dockerfile: Dockerfile
+      target: dind
+      context: .
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args:
+        - GIT_TAG_OVERRIDE=${DRONE_TAG}
+        - ARCH=arm64
+
+  - name: build_push_proxy
     image: plugins/docker
     settings:
       repo: rancher/k3d-proxy
-      tags:
-        - latest-linux-arm64
-        - "${DRONE_TAG}-linux-arm64"
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
       dockerfile: proxy/Dockerfile
       context: proxy/
       username:
@@ -315,229 +417,94 @@ steps:
         from_secret: docker_password
       build_args:
         - ARCH=arm64
-    when:
-      event:
-        - tag
 
-trigger:
-  event:
-    - tag
-
-depends_on:
-  - main
-
----
-
-kind: pipeline
-type: docker
-name: proxy_manifest
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-  - name: push_manifest
-    image: plugins/manifest
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/k3d-proxy:${DRONE_TAG}"
-      template: "rancher/k3d-proxy:${DRONE_TAG}-OS-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm
-        - linux/arm64
-    when:
-      event:
-        - tag
-
-  - name: push_manifest_latest
-    image: plugins/manifest
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/k3d-proxy:latest"
-      template: "rancher/k3d-proxy:latest-OS-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm
-        - linux/arm64
-    when:
-      event:
-        - tag
-
-trigger:
-  event:
-    - tag
-
-depends_on:
-  - main
-  - proxy_linux_amd64
-  - proxy_linux_arm
-  - proxy_linux_arm64
-
----
-#####################
-##### k3d-tools #####
-#####################
-
-kind: pipeline
-type: docker
-name: tools_linux_amd64
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-  - name: build_push
+  - name: build_push_tools
     image: plugins/docker
     settings:
       repo: rancher/k3d-tools
-      tags:
-        - latest-linux-amd64
-        - "${DRONE_TAG}-linux-amd64"
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
       dockerfile: tools/Dockerfile
       context: tools/
       username:
         from_secret: docker_username
       password:
         from_secret: docker_password
-    when:
-      event:
-        - tag
 
 trigger:
   event:
-    - tag
+    - tag # see note at the start of the "Docker Images" section: creates SemVer tagged images using the `auto_tag` option of the docker plugin
+    - push # `auto_tag` option only creates the `latest` tag if target branch is default branch (i.e. `main`)
 
 depends_on:
   - main
 
 ---
 
+##############################
+###### Docker Manifests ######
+##############################
 kind: pipeline
 type: docker
-name: tools_linux_arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-  - name: build_push
-    image: plugins/docker
-    settings:
-      repo: rancher/k3d-tools
-      tags:
-        - latest-linux-arm
-        - "${DRONE_TAG}-linux-arm"
-      dockerfile: tools/Dockerfile
-      context: tools/
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-    when:
-      event:
-        - tag
-
-trigger:
-  event:
-    - tag
-
-depends_on:
-  - main
----
-
-kind: pipeline
-type: docker
-name: tools_linux_arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-  - name: build_push
-    image: plugins/docker
-    settings:
-      repo: rancher/k3d-tools
-      tags:
-        - latest-linux-arm64
-        - "${DRONE_TAG}-linux-arm64"
-      dockerfile: tools/Dockerfile
-      context: tools/
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-    when:
-      event:
-        - tag
-
-trigger:
-  event:
-    - tag
-
-depends_on:
-  - main
----
-
-kind: pipeline
-type: docker
-name: tools_manifest
+name: manifests
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-  - name: push_manifest
+  - name: push_manifest_binary
     image: plugins/manifest
     settings:
       username:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      target: "rancher/k3d-tools:${DRONE_TAG}"
-      template: "rancher/k3d-tools:${DRONE_TAG}-OS-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm
-        - linux/arm64
-    when:
-      event:
-        - tag
+      spec: manifest.tmpl
+      auto_tag: true
+      ignore_missing: false
 
-  - name: push_manifest_latest
+  - name: push_manifest_dind
     image: plugins/manifest
     settings:
       username:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      target: "rancher/k3d-tools:latest"
-      template: "rancher/k3d-tools:latest-OS-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm
-        - linux/arm64
-    when:
-      event:
-        - tag
+      spec: dind-manifest.tmpl
+      auto_tag: true
+      ignore_missing: false
+
+  - name: push_manifest_proxy
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      spec: proxy/manifest.tmpl
+      auto_tag: true
+      ignore_missing: false
+
+  - name: push_manifest_tools
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      spec: tools/manifest.tmpl
+      auto_tag: true
+      ignore_missing: false
 
 trigger:
   event:
-    - tag
+    - tag # see note at the start of the "Docker Images" section: creates SemVer tagged images using the `auto_tag` option of the manifest plugin
+    - push # `auto_tag` option only creates the `latest` tag if target branch is default branch (i.e. `main`)
 
 depends_on:
   - main
-  - tools_linux_amd64
-  - tools_linux_arm
-  - tools_linux_arm64
+  - linux_amd64
+  - linux_arm
+  - linux_arm64
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,20 @@ RUN make build -e GIT_TAG_OVERRIDE=${GIT_TAG_OVERRIDE} && bin/k3d version
 # -> used e.g. in our CI pipelines for testing        #
 #######################################################
 FROM docker:20.10-dind as dind
+ARG OS=linux
+ARG ARCH=amd64
 
 # install some basic packages needed for testing, etc.
-RUN apk update && apk add bash curl sudo jq git make netcat-openbsd
+RUN echo "building for ${OS}/${ARCH}" && \
+    apk update && \
+    apk add bash curl sudo jq git make netcat-openbsd
 
 # install kubectl to interact with the k3d cluster
-RUN curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/${OS}/${ARCH}/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 # install yq (yaml processor) from source, as the busybox yq had some issues
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 -o /usr/bin/yq &&\
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_${OS}_${ARCH} -o /usr/bin/yq &&\
     chmod +x /usr/bin/yq
 COPY --from=builder /app/bin/k3d /bin/k3d
 

--- a/dind-manifest.tmpl
+++ b/dind-manifest.tmpl
@@ -1,0 +1,27 @@
+image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm64
+    platform:
+      variant: v8
+      architecture: arm64
+      os: linux
+  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v7
+      architecture: arm
+      os: linux
+  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v6
+      architecture: arm
+      os: linux

--- a/dind-manifest.tmpl
+++ b/dind-manifest.tmpl
@@ -1,4 +1,4 @@
-image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+image: rancher/k3d:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}dind
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,21 +6,21 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-amd64
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}dind-linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm64
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}dind-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
-  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}dind-linux-arm
     platform:
       variant: v7
       architecture: arm
       os: linux
-  - image: rancher/k3d-dind:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}dind-linux-arm
     platform:
       variant: v6
       architecture: arm

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,27 @@
+image: rancher/k3d:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm64
+    platform:
+      variant: v8
+      architecture: arm64
+      os: linux
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v7
+      architecture: arm
+      os: linux
+  - image: rancher/k3d:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v6
+      architecture: arm
+      os: linux

--- a/proxy/manifest.tmpl
+++ b/proxy/manifest.tmpl
@@ -1,0 +1,27 @@
+image: rancher/k3d-proxy:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: rancher/k3d-proxy:{{#if build.tag}}{{build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: rancher/k3d-proxy:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm64
+    platform:
+      variant: v8
+      architecture: arm64
+      os: linux
+  - image: rancher/k3d-proxy:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v7
+      architecture: arm
+      os: linux
+  - image: rancher/k3d-proxy:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v6
+      architecture: arm
+      os: linux

--- a/tools/manifest.tmpl
+++ b/tools/manifest.tmpl
@@ -1,0 +1,27 @@
+image: rancher/k3d-tools:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: rancher/k3d-tools:{{#if build.tag}}{{build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: rancher/k3d-tools:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm64
+    platform:
+      variant: v8
+      architecture: arm64
+      os: linux
+  - image: rancher/k3d-tools:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v7
+      architecture: arm
+      os: linux
+  - image: rancher/k3d-tools:{{#if build.tag}}{{build.tag}}-{{/if}}linux-arm
+    platform:
+      variant: v6
+      architecture: arm
+      os: linux


### PR DESCRIPTION
Fixes #694
Now the pipeline should build/tag/push images/manifests like follows:

<table>
<tr>
	<td>Git Event
	<td>Git Tag
	<td>Target Branch
	<td>Resulting Tags
<tr>
	<td>tag
	<td>v5.1.0 (release)
	<td>*
	<td>5, 5.1, 5.1.0 (manifest + images with `-OS-ARCH` suffix)
<tr>
	<td>tag
	<td>v5.1.0-dev.1 (pre-release)
	<td>*
	<td>5.1.0-dev.1 (manifest + images with suffix)
<tr>
	<td>push
	<td>---
	<td>main
	<td>latest (manifest + images with suffix)
<tr>
	<td>push
	<td>---
	<td>* (not main)
	<td>---
</table>

Images:
- `rancher/k3d`: `rancher/k3d:<tag>` & `rancher/k3d:<tag>-dind` <-- now also multiarch
- `rancher/k3d-proxy`
- `rancher/k3d-tools`