### PR TITLE
[Enhancement] DNS Injection

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -363,9 +363,6 @@ func NewCmdClusterCreate() *cobra.Command {
 	cmd.Flags().Bool("no-rollback", false, "Disable the automatic rollback actions, if anything goes wrong")
 	_ = cfgViper.BindPFlag("options.k3d.disablerollback", cmd.Flags().Lookup("no-rollback"))
 
-	cmd.Flags().Bool("no-hostip", false, "Disable the automatic injection of the Host IP as 'host.k3d.internal' into the containers and CoreDNS")
-	_ = cfgViper.BindPFlag("options.k3d.disablehostipinjection", cmd.Flags().Lookup("no-hostip"))
-
 	cmd.Flags().String("gpus", "", "GPU devices to add to the cluster node containers ('all' to pass all GPUs) [From docker]")
 	_ = cfgViper.BindPFlag("options.runtime.gpurequest", cmd.Flags().Lookup("gpus"))
 

--- a/docs/usage/configfile.md
+++ b/docs/usage/configfile.md
@@ -92,7 +92,6 @@ options:
     disableLoadbalancer: false # same as `--no-lb`
     disableImageVolume: false # same as `--no-image-volume`
     disableRollback: false # same as `--no-Rollback`
-    disableHostIPInjection: false # same as `--no-hostip`
   k3s: # options passed on to K3s itself
     extraArgs: # additional arguments passed to the `k3s server|agent` command; same as `--k3s-arg`
       - arg: --tls-san=my.host.domain

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3 // indirect
 	github.com/Microsoft/hcsshim v0.8.14 // indirect
 	github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68 // indirect
-	github.com/containerd/containerd v1.4.4 // indirect
+	github.com/containerd/containerd v1.4.4
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e // indirect
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/docker v20.10.7+incompatible

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -38,9 +38,6 @@ func ProcessClusterConfig(clusterConfig conf.ClusterConfig) (*conf.ClusterConfig
 		l.Log().Debugf("Host network was chosen, changing provided/random api port to k3s:%s", k3sPort)
 		cluster.KubeAPI.PortMapping.Binding.HostPort = k3sPort
 
-		// if network is host, dont inject docker host into the cluster
-		clusterConfig.ClusterCreateOpts.PrepDisableHostIPInjection = true
-
 		// if network is host, disable load balancer
 		// serverlb not supported in hostnetwork mode due to port collisions with server node
 		clusterConfig.ClusterCreateOpts.DisableLoadBalancer = true

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -55,7 +55,6 @@ func TestProcessClusterConfig(t *testing.T) {
 
 	clusterCfg, err = ProcessClusterConfig(*clusterCfg)
 	assert.Assert(t, clusterCfg.ClusterCreateOpts.DisableLoadBalancer == false, "The load balancer should be enabled")
-	assert.Assert(t, clusterCfg.ClusterCreateOpts.PrepDisableHostIPInjection == false, "The host ip injection should be enabled")
 
 	t.Logf("\n===== Resulting Cluster Config (non-host network) =====\n%+v\n===============\n", clusterCfg)
 
@@ -64,7 +63,6 @@ func TestProcessClusterConfig(t *testing.T) {
 	clusterCfg.Cluster.Network.Name = "host"
 	clusterCfg, err = ProcessClusterConfig(*clusterCfg)
 	assert.Assert(t, clusterCfg.ClusterCreateOpts.DisableLoadBalancer == true, "The load balancer should be disabled")
-	assert.Assert(t, clusterCfg.ClusterCreateOpts.PrepDisableHostIPInjection == true, "The host ip injection should be disabled")
 
 	t.Logf("\n===== Resulting Cluster Config (host network) =====\n%+v\n===============\n", clusterCfg)
 

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -261,16 +261,15 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 	 **************************/
 
 	clusterCreateOpts := k3d.ClusterCreateOpts{
-		PrepDisableHostIPInjection: simpleConfig.Options.K3dOptions.PrepDisableHostIPInjection,
-		DisableImageVolume:         simpleConfig.Options.K3dOptions.DisableImageVolume,
-		WaitForServer:              simpleConfig.Options.K3dOptions.Wait,
-		Timeout:                    simpleConfig.Options.K3dOptions.Timeout,
-		DisableLoadBalancer:        simpleConfig.Options.K3dOptions.DisableLoadbalancer,
-		GPURequest:                 simpleConfig.Options.Runtime.GPURequest,
-		ServersMemory:              simpleConfig.Options.Runtime.ServersMemory,
-		AgentsMemory:               simpleConfig.Options.Runtime.AgentsMemory,
-		GlobalLabels:               map[string]string{}, // empty init
-		GlobalEnv:                  []string{},          // empty init
+		DisableImageVolume:  simpleConfig.Options.K3dOptions.DisableImageVolume,
+		WaitForServer:       simpleConfig.Options.K3dOptions.Wait,
+		Timeout:             simpleConfig.Options.K3dOptions.Timeout,
+		DisableLoadBalancer: simpleConfig.Options.K3dOptions.DisableLoadbalancer,
+		GPURequest:          simpleConfig.Options.Runtime.GPURequest,
+		ServersMemory:       simpleConfig.Options.Runtime.ServersMemory,
+		AgentsMemory:        simpleConfig.Options.Runtime.AgentsMemory,
+		GlobalLabels:        map[string]string{}, // empty init
+		GlobalEnv:           []string{},          // empty init
 	}
 
 	// ensure, that we have the default object labels

--- a/pkg/config/v1alpha3/schema.json
+++ b/pkg/config/v1alpha3/schema.json
@@ -137,10 +137,6 @@
             "disableRollback": {
               "type": "boolean",
               "default": false
-            },
-            "disableHostIPInjection": {
-              "type": "boolean",
-              "default": false
             }
           },
           "additionalProperties": false

--- a/pkg/config/v1alpha3/types.go
+++ b/pkg/config/v1alpha3/types.go
@@ -102,13 +102,12 @@ type SimpleConfigOptionsRuntime struct {
 }
 
 type SimpleConfigOptionsK3d struct {
-	Wait                       bool                 `mapstructure:"wait" yaml:"wait"`
-	Timeout                    time.Duration        `mapstructure:"timeout" yaml:"timeout"`
-	DisableLoadbalancer        bool                 `mapstructure:"disableLoadbalancer" yaml:"disableLoadbalancer"`
-	DisableImageVolume         bool                 `mapstructure:"disableImageVolume" yaml:"disableImageVolume"`
-	NoRollback                 bool                 `mapstructure:"disableRollback" yaml:"disableRollback"`
-	PrepDisableHostIPInjection bool                 `mapstructure:"disableHostIPInjection" yaml:"disableHostIPInjection"`
-	NodeHookActions            []k3d.NodeHookAction `mapstructure:"nodeHookActions" yaml:"nodeHookActions,omitempty"`
+	Wait                bool                 `mapstructure:"wait" yaml:"wait"`
+	Timeout             time.Duration        `mapstructure:"timeout" yaml:"timeout"`
+	DisableLoadbalancer bool                 `mapstructure:"disableLoadbalancer" yaml:"disableLoadbalancer"`
+	DisableImageVolume  bool                 `mapstructure:"disableImageVolume" yaml:"disableImageVolume"`
+	NoRollback          bool                 `mapstructure:"disableRollback" yaml:"disableRollback"`
+	NodeHookActions     []k3d.NodeHookAction `mapstructure:"nodeHookActions" yaml:"nodeHookActions,omitempty"`
 }
 
 type SimpleConfigOptionsK3s struct {

--- a/pkg/runtimes/docker/network.go
+++ b/pkg/runtimes/docker/network.go
@@ -69,6 +69,10 @@ func (d Docker) GetNetwork(ctx context.Context, searchNet *k3d.ClusterNetwork) (
 		return nil, err
 	}
 
+	if len(networkList) == 0 {
+		return nil, runtimeErr.ErrRuntimeNetworkNotExists
+	}
+
 	targetNetwork, err := docker.NetworkInspect(ctx, networkList[0].ID, types.NetworkInspectOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect network %s: %w", networkList[0].Name, err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -164,18 +164,17 @@ var DoNotCopyServerFlags = []string{
 
 // ClusterCreateOpts describe a set of options one can set when creating a cluster
 type ClusterCreateOpts struct {
-	PrepDisableHostIPInjection bool              `yaml:"prepDisableHostIPInjection" json:"prepDisableHostIPInjection,omitempty"`
-	DisableImageVolume         bool              `yaml:"disableImageVolume" json:"disableImageVolume,omitempty"`
-	WaitForServer              bool              `yaml:"waitForServer" json:"waitForServer,omitempty"`
-	Timeout                    time.Duration     `yaml:"timeout" json:"timeout,omitempty"`
-	DisableLoadBalancer        bool              `yaml:"disableLoadbalancer" json:"disableLoadbalancer,omitempty"`
-	GPURequest                 string            `yaml:"gpuRequest" json:"gpuRequest,omitempty"`
-	ServersMemory              string            `yaml:"serversMemory" json:"serversMemory,omitempty"`
-	AgentsMemory               string            `yaml:"agentsMemory" json:"agentsMemory,omitempty"`
-	NodeHooks                  []NodeHook        `yaml:"nodeHooks,omitempty" json:"nodeHooks,omitempty"`
-	GlobalLabels               map[string]string `yaml:"globalLabels,omitempty" json:"globalLabels,omitempty"`
-	GlobalEnv                  []string          `yaml:"globalEnv,omitempty" json:"globalEnv,omitempty"`
-	Registries                 struct {
+	DisableImageVolume  bool              `yaml:"disableImageVolume" json:"disableImageVolume,omitempty"`
+	WaitForServer       bool              `yaml:"waitForServer" json:"waitForServer,omitempty"`
+	Timeout             time.Duration     `yaml:"timeout" json:"timeout,omitempty"`
+	DisableLoadBalancer bool              `yaml:"disableLoadbalancer" json:"disableLoadbalancer,omitempty"`
+	GPURequest          string            `yaml:"gpuRequest" json:"gpuRequest,omitempty"`
+	ServersMemory       string            `yaml:"serversMemory" json:"serversMemory,omitempty"`
+	AgentsMemory        string            `yaml:"agentsMemory" json:"agentsMemory,omitempty"`
+	NodeHooks           []NodeHook        `yaml:"nodeHooks,omitempty" json:"nodeHooks,omitempty"`
+	GlobalLabels        map[string]string `yaml:"globalLabels,omitempty" json:"globalLabels,omitempty"`
+	GlobalEnv           []string          `yaml:"globalEnv,omitempty" json:"globalEnv,omitempty"`
+	Registries          struct {
 		Create *Registry     `yaml:"create,omitempty" json:"create,omitempty"`
 		Use    []*Registry   `yaml:"use,omitempty" json:"use,omitempty"`
 		Config *k3s.Registry `yaml:"config,omitempty" json:"config,omitempty"` // registries.yaml (k3s config for containerd registry override)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -246,12 +246,18 @@ type IPAM struct {
 	Managed  bool             // IPAM is done by k3d
 }
 
+type NetworkMember struct {
+	Name string
+	IP   netaddr.IP
+}
+
 // ClusterNetwork describes a network which a cluster is running in
 type ClusterNetwork struct {
 	Name     string `yaml:"name" json:"name,omitempty"`
 	ID       string `yaml:"id" json:"id"` // may be the same as name, but e.g. docker only differentiates by random ID, not by name
 	External bool   `yaml:"external" json:"isExternal,omitempty"`
 	IPAM     IPAM   `yaml:"ipam" json:"ipam,omitempty"`
+	Members  []*NetworkMember
 }
 
 // Cluster describes a k3d cluster
@@ -323,7 +329,7 @@ type Node struct {
 	GPURequest    string            // filled automatically
 	Memory        string            // filled automatically
 	State         NodeState         // filled automatically
-	IP            NodeIP            // filled automatically
+	IP            NodeIP            // filled automatically -> refers solely to the cluster network
 	HookActions   []NodeHook        `yaml:"hooks" json:"hooks,omitempty"`
 }
 


### PR DESCRIPTION
This PR changes several parts related to actions k3d is taking to modify DNS in k3d managed clusters.
Here's an excerpt:

- remove`--no-hostip` flag and the related `disableHostIPInjection` config option
- inject host IP on every cluster startup (except when hostnetwork is chosen)
	- this includes an entry in `/etc/hosts` and in the CoreDNS configmap
	- fixes #401 
- inject host entries for every cluster network member container into the CoreDNS configmap
	- fixes #522 