### PR TITLE
[Feature] Spread config file usage in CLI: `k3d cluster delete --config myconfig.yaml`

### DIFF
--- a/cmd/util/config/config.go
+++ b/cmd/util/config/config.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2020-2021 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rancher/k3d/v4/pkg/config"
+	l "github.com/rancher/k3d/v4/pkg/logger"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+func InitViperWithConfigFile(cfgViper *viper.Viper, configFile string) error {
+
+	// viper for the general config (file, env and non pre-processed flags)
+	cfgViper.SetEnvPrefix("K3D")
+	cfgViper.AutomaticEnv()
+
+	cfgViper.SetConfigType("yaml")
+
+	// Set config file, if specified
+	if configFile != "" {
+
+		if _, err := os.Stat(configFile); err != nil {
+			l.Log().Fatalf("Failed to stat config file %s: %+v", configFile, err)
+		}
+
+		// create temporary file to expand environment variables in the config without writing that back to the original file
+		// we're doing it here, because this happens just before absolutely all other processing
+		tmpfile, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("k3d-config-tmp-%s", filepath.Base(configFile)))
+		if err != nil {
+			l.Log().Fatalf("error creating temp copy of configfile %s for variable expansion: %v", configFile, err)
+		}
+		defer tmpfile.Close()
+
+		originalcontent, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			l.Log().Fatalf("error reading config file %s: %v", configFile, err)
+		}
+		expandedcontent := os.ExpandEnv(string(originalcontent))
+		if _, err := tmpfile.WriteString(expandedcontent); err != nil {
+			l.Log().Fatalf("error writing expanded config file contents to temp file %s: %v", tmpfile.Name(), err)
+		}
+
+		// use temp file with expanded variables
+		cfgViper.SetConfigFile(tmpfile.Name())
+
+		// try to read config into memory (viper map structure)
+		if err := cfgViper.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				l.Log().Fatalf("Config file %s not found: %+v", configFile, err)
+			}
+			// config file found but some other error happened
+			l.Log().Fatalf("Failed to read config file %s: %+v", configFile, err)
+		}
+
+		schema, err := config.GetSchemaByVersion(cfgViper.GetString("apiVersion"))
+		if err != nil {
+			l.Log().Fatalf("Cannot validate config file %s: %+v", configFile, err)
+		}
+
+		if err := config.ValidateSchemaFile(configFile, schema); err != nil {
+			l.Log().Fatalf("Schema Validation failed for config file %s: %+v", configFile, err)
+		}
+
+		l.Log().Infof("Using config file %s (%s#%s)", configFile, strings.ToLower(cfgViper.GetString("apiVersion")), strings.ToLower(cfgViper.GetString("kind")))
+	}
+	if l.Log().GetLevel() >= logrus.DebugLevel {
+		c, _ := yaml.Marshal(cfgViper.AllSettings())
+		l.Log().Debugf("Configuration:\n%s", c)
+	}
+	return nil
+}


### PR DESCRIPTION
- move viper initialization from k3d config file to separate util
sub-package in cmd/
- use that new subpackage init function to leverage the config file in
`k3d cluster delete` -> the delete function only cares about the `name` of the cluster and does not check anything else in the config file!
- cover that with an e2e test case

fixes  https://github.com/rancher/k3d/issues/715