### PR TITLE
[Feature] CreateNode: add token and network flags and allow remote cluster

### DIFF
--- a/cmd/node/nodeCreate.go
+++ b/cmd/node/nodeCreate.go
@@ -50,10 +50,17 @@ func NewCmdNodeCreate() *cobra.Command {
 		Long:  `Create a new containerized k3s node (k3s in docker).`,
 		Args:  cobra.ExactArgs(1), // exactly one name accepted // TODO: if not specified, inherit from cluster that the node shall belong to, if that is specified
 		Run: func(cmd *cobra.Command, args []string) {
-			nodes, cluster := parseCreateNodeCmd(cmd, args)
-			if err := k3dc.NodeAddToClusterMulti(cmd.Context(), runtimes.SelectedRuntime, nodes, cluster, createNodeOpts); err != nil {
-				l.Log().Errorf("Failed to add nodes to cluster '%s'", cluster.Name)
-				l.Log().Fatalln(err)
+			nodes, clusterName := parseCreateNodeCmd(cmd, args)
+			if strings.HasPrefix(clusterName, "https://") {
+				l.Log().Infof("Adding %d node(s) to the remote cluster '%s'...", len(nodes), clusterName)
+				if err := k3dc.NodeAddToClusterMultiRemote(cmd.Context(), runtimes.SelectedRuntime, clusterName, createNodeOpts); err != nil {
+					l.Log().Fatalf("failed to add %d node(s) to the remote cluster '%s': %v", len(nodes), clusterName, err)
+				}
+			} else {
+				l.Log().Infof("Adding %d node(s) to the runtime local cluster '%s'...", len(nodes), clusterName)
+				if err := k3dc.NodeAddToClusterMulti(cmd.Context(), runtimes.SelectedRuntime, nodes, &k3d.Cluster{Name: clusterName}, createNodeOpts); err != nil {
+					l.Log().Fatalf("failed to add %d node(s) to the runtime local cluster '%s': %v", len(nodes), clusterName, err)
+				}
 			}
 			l.Log().Infof("Successfully created %d node(s)!", len(nodes))
 		},
@@ -79,12 +86,14 @@ func NewCmdNodeCreate() *cobra.Command {
 	cmd.Flags().StringSliceP("runtime-label", "", []string{}, "Specify container runtime labels in format \"foo=bar\"")
 	cmd.Flags().StringSliceP("k3s-node-label", "", []string{}, "Specify k3s node labels in format \"foo=bar\"")
 
+	cmd.Flags().StringArrayP("network", "n", []string{}, "Add node to (another) runtime network")
+
 	// done
 	return cmd
 }
 
-// parseCreateNodeCmd parses the command input into variables required to create a cluster
-func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, *k3d.Cluster) {
+// parseCreateNodeCmd parses the command input into variables required to create a node
+func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, string) {
 
 	// --replicas
 	replicas, err := cmd.Flags().GetInt("replicas")
@@ -115,9 +124,6 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, *k3d.Cl
 	clusterName, err := cmd.Flags().GetString("cluster")
 	if err != nil {
 		l.Log().Fatalln(err)
-	}
-	cluster := &k3d.Cluster{
-		Name: clusterName,
 	}
 
 	// --memory
@@ -166,6 +172,8 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, *k3d.Cl
 		k3sNodeLabels[labelSplitted[0]] = labelSplitted[1]
 	}
 
+	// --network
+
 	// generate list of nodes
 	nodes := []*k3d.Node{}
 	for i := 0; i < replicas; i++ {
@@ -181,5 +189,5 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, *k3d.Cl
 		nodes = append(nodes, node)
 	}
 
-	return nodes, cluster
+	return nodes, clusterName
 }

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -372,7 +372,7 @@ ClusterCreatOpts:
 	// connection url is always the name of the first server node (index 0) // TODO: change this to the server loadbalancer
 	connectionURL := fmt.Sprintf("https://%s:%s", GenerateNodeName(cluster.Name, k3d.ServerRole, 0), k3d.DefaultAPIPort)
 	clusterCreateOpts.GlobalLabels[k3d.LabelClusterURL] = connectionURL
-	clusterCreateOpts.GlobalEnv = append(clusterCreateOpts.GlobalEnv, fmt.Sprintf("K3S_TOKEN=%s", cluster.Token))
+	clusterCreateOpts.GlobalEnv = append(clusterCreateOpts.GlobalEnv, fmt.Sprintf("%s=%s", k3d.K3sEnvClusterToken, cluster.Token))
 
 	nodeSetup := func(node *k3d.Node) error {
 		// cluster specific settings
@@ -406,12 +406,12 @@ ClusterCreatOpts:
 
 			// the cluster has an init server node, but its not this one, so connect it to the init node
 			if cluster.InitNode != nil && !node.ServerOpts.IsInit {
-				node.Env = append(node.Env, fmt.Sprintf("K3S_URL=%s", connectionURL))
+				node.Env = append(node.Env, fmt.Sprintf("%s=%s", k3d.K3sEnvClusterConnectURL, connectionURL))
 				node.RuntimeLabels[k3d.LabelServerIsInit] = "false" // set label, that this server node is not the init server
 			}
 
 		} else if node.Role == k3d.AgentRole {
-			node.Env = append(node.Env, fmt.Sprintf("K3S_URL=%s", connectionURL))
+			node.Env = append(node.Env, fmt.Sprintf("%s=%s", k3d.K3sEnvClusterConnectURL, connectionURL))
 		}
 
 		node.Networks = []string{cluster.Network.Name}

--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -245,7 +245,7 @@ func runToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cl
 		Networks:      []string{network},
 		Cmd:           []string{},
 		Args:          []string{"noop"},
-		RuntimeLabels: k3d.DefaultRuntimeLabels,
+		RuntimeLabels: labels,
 	}
 	node.RuntimeLabels[k3d.LabelClusterName] = cluster.Name
 	if err := NodeRun(ctx, runtime, node, k3d.NodeCreateOpts{}); err != nil {

--- a/pkg/runtimes/docker/network.go
+++ b/pkg/runtimes/docker/network.go
@@ -157,6 +157,11 @@ func (d Docker) CreateNetworkIfNotPresent(ctx context.Context, inNet *k3d.Cluste
 		return existingNet, true, nil
 	}
 
+	labels := make(map[string]string, 0)
+	for k, v := range k3d.DefaultRuntimeLabels {
+		labels[k] = v
+	}
+
 	// (3) Create a new network
 	netCreateOpts := types.NetworkCreate{
 		Driver: "bridge",
@@ -164,7 +169,7 @@ func (d Docker) CreateNetworkIfNotPresent(ctx context.Context, inNet *k3d.Cluste
 			"com.docker.network.bridge.enable_ip_masquerade": "true",
 		},
 		CheckDuplicate: true,
-		Labels:         k3d.DefaultRuntimeLabels,
+		Labels:         labels,
 	}
 
 	// we want a managed (user-defined) network, but user didn't specify a subnet, so we try to auto-generate one

--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -186,7 +186,7 @@ func getContainersByLabel(ctx context.Context, labels map[string]string) ([]type
 		All:     true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to list containers: %+v", err)
+		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
 
 	return containers, nil

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -22,17 +22,18 @@ THE SOFTWARE.
 package types
 
 func (node *Node) FillRuntimeLabels() {
-	labels := make(map[string]string)
+	if node.RuntimeLabels == nil {
+		node.RuntimeLabels = make(map[string]string)
+	}
 	for k, v := range DefaultRuntimeLabels {
-		labels[k] = v
+		node.RuntimeLabels[k] = v
 	}
 	for k, v := range DefaultRuntimeLabelsVar {
-		labels[k] = v
+		node.RuntimeLabels[k] = v
 	}
 	for k, v := range node.RuntimeLabels {
-		labels[k] = v
+		node.RuntimeLabels[k] = v
 	}
-	node.RuntimeLabels = labels
 	// second most important: the node role label
 	node.RuntimeLabels[LabelRole] = string(node.Role)
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -106,6 +106,7 @@ const (
 	LabelClusterName          string = "k3d.cluster"
 	LabelClusterURL           string = "k3d.cluster.url"
 	LabelClusterToken         string = "k3d.cluster.token"
+	LabelClusterExternal      string = "k3d.cluster.external"
 	LabelImageVolume          string = "k3d.cluster.imageVolume"
 	LabelNetworkExternal      string = "k3d.cluster.network.external"
 	LabelNetwork              string = "k3d.cluster.network"
@@ -137,8 +138,15 @@ var DefaultTmpfsMounts = []string{
 
 // DefaultNodeEnv defines some default environment variables that should be set on every node
 var DefaultNodeEnv = []string{
-	"K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml",
+	fmt.Sprintf("%s=/output/kubeconfig.yaml", K3sEnvKubeconfigOutput),
 }
+
+// k3s environment variables
+const (
+	K3sEnvClusterToken      string = "K3S_TOKEN"
+	K3sEnvClusterConnectURL string = "K3S_URL"
+	K3sEnvKubeconfigOutput  string = "K3S_KUBECONFIG_OUTPUT"
+)
 
 // DefaultK3dInternalHostRecord defines the default /etc/hosts entry for the k3d host
 const DefaultK3dInternalHostRecord = "host.k3d.internal"
@@ -216,6 +224,7 @@ type NodeCreateOpts struct {
 	Timeout         time.Duration
 	NodeHooks       []NodeHook `yaml:"nodeHooks,omitempty" json:"nodeHooks,omitempty"`
 	EnvironmentInfo *EnvironmentInfo
+	ClusterToken    string
 }
 
 // NodeStartOpts describes a set of options one can set when (re-)starting a node


### PR DESCRIPTION
## Changes

- `--cluster` flag parsed for `https://` prefix and node creation treated differently accordingly
- new `--network` string array flag to add the node to multiple networks (primary network when adding to a remote cluster)
- new `--token` flag to provide the cluster token

Note: currently this is very simple, as it e.g. does not check for special cases like when someone overrides the "reserved" K3s environment variables (`K3S_URL`, `K3S_TOKEN` and `K3S_KUBECONFIG_OUTPUT`).
Those will be specified via the `--cluster` and `--token` flags only.

Note2: `--network` is required when connecting to a cluster running in a different docker network, as the node has to join that network for communication to work.

## Validation Test

```bash
# 1. create a normal k3d cluster
k3d cluster create simremote
# ...

# 2. Get Kubernetes API Port (exposed on the host) and cluster token
apiport=$(docker inspect k3d-simremote-server-0 --format '{{ index .Config.Labels "k3d.server.api.port"}}')

clustertoken=$(docker inspect k3d-simremote-server-0 --format '{{ index .Config.Labels "k3d.cluster.token"}}')

# 3. Get Host IP, e.g. from `ip a`
localip=192.168.178.12 # <- EXAMPLE

# 4. Create new node connecting to the cluster "remotely"
k3d node create testnode --role agent --cluster "https://$localip:$apiport" --token "$clustertoken"
# ...

# 5. Use kubectl to verify that the new node is there
kubectl get nodes 

NAME                     STATUS   ROLES                  AGE   VERSION
k3d-simremote-server-0   Ready    control-plane,master   18m   v1.21.4+k3s1
k3d-testnode-0           Ready    <none>                 15m   v1.21.4+k3s1
```

## Links

fixes #549 