### PR TITLE
[Feature] Loadbalancer config overrides

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -343,6 +343,10 @@ func NewCmdClusterCreate() *cobra.Command {
 		l.Log().Fatalln("Failed to mark flag 'config' as filename flag")
 	}
 
+	/* Loadbalancer / Proxy */
+	cmd.Flags().StringSlice("lb-config-override", nil, "Use dotted YAML path syntax to override nginx loadbalancer settings")
+	_ = cfgViper.BindPFlag("options.k3d.loadbalancer.configoverrides", cmd.Flags().Lookup("lb-config-override"))
+
 	/* Subcommands */
 
 	// done

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -495,6 +495,7 @@ ClusterCreatOpts:
 	// *** ServerLoadBalancer ***
 	if !clusterCreateOpts.DisableLoadBalancer {
 		if cluster.ServerLoadBalancer == nil {
+			l.Log().Infof("No loadbalancer specified, creating a default one...")
 			lbNode, err := LoadbalancerPrepare(ctx, runtime, cluster, &k3d.LoadbalancerCreateOpts{Labels: clusterCreateOpts.GlobalLabels})
 			if err != nil {
 				return fmt.Errorf("failed to prepare loadbalancer: %w", err)

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -111,8 +111,12 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 
 	if !simpleConfig.Options.K3dOptions.DisableLoadbalancer {
 		newCluster.ServerLoadBalancer = k3d.NewLoadbalancer()
+		lbCreateOpts := &k3d.LoadbalancerCreateOpts{}
+		if simpleConfig.Options.K3dOptions.Loadbalancer.ConfigOverrides != nil && len(simpleConfig.Options.K3dOptions.Loadbalancer.ConfigOverrides) > 0 {
+			lbCreateOpts.ConfigOverrides = simpleConfig.Options.K3dOptions.Loadbalancer.ConfigOverrides
+		}
 		var err error
-		newCluster.ServerLoadBalancer.Node, err = client.LoadbalancerPrepare(ctx, runtime, &newCluster, nil)
+		newCluster.ServerLoadBalancer.Node, err = client.LoadbalancerPrepare(ctx, runtime, &newCluster, lbCreateOpts)
 		if err != nil {
 			return nil, fmt.Errorf("error preparing the loadbalancer: %w", err)
 		}

--- a/pkg/config/v1alpha3/types.go
+++ b/pkg/config/v1alpha3/types.go
@@ -102,12 +102,17 @@ type SimpleConfigOptionsRuntime struct {
 }
 
 type SimpleConfigOptionsK3d struct {
-	Wait                bool                 `mapstructure:"wait" yaml:"wait"`
-	Timeout             time.Duration        `mapstructure:"timeout" yaml:"timeout"`
-	DisableLoadbalancer bool                 `mapstructure:"disableLoadbalancer" yaml:"disableLoadbalancer"`
-	DisableImageVolume  bool                 `mapstructure:"disableImageVolume" yaml:"disableImageVolume"`
-	NoRollback          bool                 `mapstructure:"disableRollback" yaml:"disableRollback"`
-	NodeHookActions     []k3d.NodeHookAction `mapstructure:"nodeHookActions" yaml:"nodeHookActions,omitempty"`
+	Wait                bool                               `mapstructure:"wait" yaml:"wait"`
+	Timeout             time.Duration                      `mapstructure:"timeout" yaml:"timeout"`
+	DisableLoadbalancer bool                               `mapstructure:"disableLoadbalancer" yaml:"disableLoadbalancer"`
+	DisableImageVolume  bool                               `mapstructure:"disableImageVolume" yaml:"disableImageVolume"`
+	NoRollback          bool                               `mapstructure:"disableRollback" yaml:"disableRollback"`
+	NodeHookActions     []k3d.NodeHookAction               `mapstructure:"nodeHookActions" yaml:"nodeHookActions,omitempty"`
+	Loadbalancer        SimpleConfigOptionsK3dLoadbalancer `mapstructure:"loadbalancer" yaml:"loadbalancer,omitempty"`
+}
+
+type SimpleConfigOptionsK3dLoadbalancer struct {
+	ConfigOverrides []string `mapstructure:"configOverrides" yaml:"configOverrides,omitempty"`
 }
 
 type SimpleConfigOptionsK3s struct {

--- a/pkg/types/loadbalancer.go
+++ b/pkg/types/loadbalancer.go
@@ -73,7 +73,8 @@ type LoadbalancerConfig struct {
 }
 
 type LoadBalancerSettings struct {
-	WorkerProcesses int `yaml:"workerProcesses"`
+	WorkerProcesses     int `yaml:"workerProcesses"`
+	DefaultProxyTimeout int `yaml:"defaultProxyTimeout,omitempty"`
 }
 
 const (
@@ -82,7 +83,8 @@ const (
 )
 
 type LoadbalancerCreateOpts struct {
-	Labels map[string]string
+	Labels          map[string]string
+	ConfigOverrides []string
 }
 
 /*

--- a/proxy/templates/nginx.tmpl
+++ b/proxy/templates/nginx.tmpl
@@ -33,7 +33,7 @@ stream {
   server {
     listen        {{ $port }} {{- if (eq $protocol "udp") }} udp{{- end -}};
     proxy_pass    {{ $upstream }};
-    proxy_timeout 600;
+    proxy_timeout {{ getv "/settings/defaultProxyTimeout" "600" }};
     proxy_connect_timeout 2s;
   }
 


### PR DESCRIPTION
## Changes

- allow overriding k3d-proxy settings (workerProcesses,
defaultProxyTimeout) via CLI `--lb-config-override` stringslice flag (see example)
- add new field to loadbalancer config and SimpleConfig structs

## Example

```bash
k3d cluster create testlbconfig --lb-config-override "settings.defaultProxyTimeout=300" --lb-config-override "settings.workerProcesses=2048"
```

results in the following loadbalancer config (`docker logs k3d-testlbconfig-serverlb`):
```bash
===== Initial nginx configuration =====
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
# configuration file /etc/nginx/nginx.conf:
###################################
# Generated by confd 2021-09-07 06:11:23.236402085 +0000 UTC m=+0.013360863 #
#             #######             #
#             # k3d #             #
#             #######             #
###################################

error_log stderr notice;

worker_processes auto;
events {
  multi_accept on;
  use epoll;
  worker_connections 2048;
}

stream {

  upstream 6443_tcp {
    server k3d-testlbconfig2-server-0:6443 max_fails=1 fail_timeout=10s;
  }

  server {
    listen        6443;
    proxy_pass    6443_tcp;
    proxy_timeout 300;
    proxy_connect_timeout 2s;
  }

}

```

### Config file

The equivalent in the `SimpleConfig` would be 
```yaml
apiVersion: k3d.io/v1alpha3
kind: Simple
options:
  k3d:
    loadbalancer:
      configOverrides:
        - settings.defaultProxyTimeout=300
        - settings.workerProcesses=2048
```

## Links

- fixes #707 
