### PR TITLE
Add a step of modifying /etc/hosts for registries docs

### DIFF
--- a/docs/usage/registries.md
+++ b/docs/usage/registries.md
@@ -98,12 +98,9 @@ k3d cluster create \
   - the port, which the registry is listening on will be mapped to a random port on your host system
 
 2. Check the k3d command output or `#!bash docker ps -f name=mycluster-registry` to find the exposed port (let's use `12345` here)
-3. Add the created registry to your `/etc/hosts` file (`c:\windows\system32\drivers\etc\hosts` on Windows) so that you can push to it (notice the `k3d-` prefix):
-```bash
-127.0.0.1 k3d-mycluster-registry
-```
-4. Pull some image (optional) `#!bash docker pull alpine:latest`, re-tag it to reference your newly created registry `#!bash docker tag alpine:latest mycluster-registry:12345/testimage:local` and push it `#!bash docker push mycluster-registry:12345/testimage:local`
-5. Use kubectl to create a new pod in your cluster using that image to see, if the cluster can pull from the new registry: `#!bash kubectl run --image mycluster-registry:12345/testimage:local testimage --command -- tail -f /dev/null` (creates a container that will not do anything but keep on running)
+3. Pull some image (optional) `#!bash docker pull alpine:latest`, re-tag it to reference your newly created registry `#!bash docker tag alpine:latest mycluster-registry:12345/testimage:local` and push it `#!bash docker push mycluster-registry:12345/testimage:local`
+  - If the push fails with `dial tcp: lookup k3d-mycluster-registry: Temporary failure in name resolution`, follow the guide on [pushing to your local registry address](#pushing-to-your-local-registry-address).
+4. Use kubectl to create a new pod in your cluster using that image to see, if the cluster can pull from the new registry: `#!bash kubectl run --image mycluster-registry:12345/testimage:local testimage --command -- tail -f /dev/null` (creates a container that will not do anything but keep on running)
 
 #### Create a customized k3d-managed registry
 

--- a/docs/usage/registries.md
+++ b/docs/usage/registries.md
@@ -98,8 +98,12 @@ k3d cluster create \
   - the port, which the registry is listening on will be mapped to a random port on your host system
 
 2. Check the k3d command output or `#!bash docker ps -f name=mycluster-registry` to find the exposed port (let's use `12345` here)
-3. Pull some image (optional) `#!bash docker pull alpine:latest`, re-tag it to reference your newly created registry `#!bash docker tag alpine:latest mycluster-registry:12345/testimage:local` and push it `#!bash docker push mycluster-registry:12345/testimage:local`
-4. Use kubectl to create a new pod in your cluster using that image to see, if the cluster can pull from the new registry: `#!bash kubectl run --image mycluster-registry:12345/testimage:local testimage --command -- tail -f /dev/null` (creates a container that will not do anything but keep on running)
+3. Add the created registry to your `/etc/hosts` file (`c:\windows\system32\drivers\etc\hosts` on Windows) so that you can push to it (notice the `k3d-` prefix):
+```bash
+127.0.0.1 k3d-mycluster-registry
+```
+4. Pull some image (optional) `#!bash docker pull alpine:latest`, re-tag it to reference your newly created registry `#!bash docker tag alpine:latest mycluster-registry:12345/testimage:local` and push it `#!bash docker push mycluster-registry:12345/testimage:local`
+5. Use kubectl to create a new pod in your cluster using that image to see, if the cluster can pull from the new registry: `#!bash kubectl run --image mycluster-registry:12345/testimage:local testimage --command -- tail -f /dev/null` (creates a container that will not do anything but keep on running)
 
 #### Create a customized k3d-managed registry
 


### PR DESCRIPTION
# What

Add an step in the ["Create a dedicated registry together with your cluster"](https://k3d.io/v4.4.8/usage/guides/registries/#create-a-dedicated-registry-together-with-your-cluster) guide about having to also modify your `/etc/hosts` file to add the registry to it.

# Why

I followed the steps laid out in the docs, and pushing to the local registry didn't work for me. The error I got was (port was 46605 for me):
```shell
Get "https://k3d-mycluster-registry:46605/v2/": dial tcp: lookup k3d-mycluster-registry: Temporary failure in name resolution
```

Env:
Ubuntu 20.04
k3d version v4.4.8
k3s version v1.21.3-k3s1 (default)

Related issue https://github.com/rancher/k3d/issues/755 is about using the ["Create a customized k3d-managed registry"](https://k3d.io/v4.4.8/usage/guides/registries/#create-a-customized-k3d-managed-registry) guide and the solution in that issue was to edit the `/etc/hosts` file and that worked perfectly for me and the `docker push` started working. It's not 100% the same issue, as it deals with the `.localhost` postfix, but the idea is the same.

Or maybe my approach is all wrong and it's something on my system that's wrong then. This just seemed like the simples fix that I stumbled across.

# Implications

People's `/etc/hosts` will never be the same

<!-- Get recognized using our all-contributors bot: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
