### PR TITLE
fix: do not do any network magic when using hostnetwork

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -948,6 +948,11 @@ func ClusterStart(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clust
 
 	postStartErrgrp.Go(func() error {
 
+		if cluster.Network.Name == "host" {
+			l.Log().Debugf("Not injecting host.k3d.internal into CoreDNS as clusternetwork is 'host'")
+			return nil
+		}
+
 		hosts := fmt.Sprintf("%s %s\n", clusterStartOpts.EnvironmentInfo.HostGateway.String(), k3d.DefaultK3dInternalHostRecord)
 
 		net, err := runtime.GetNetwork(ctx, &cluster.Network)
@@ -1101,7 +1106,7 @@ func corednsAddHost(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clu
 // prepInjectHostIP adds /etc/hosts entry for host.k3d.internal, referring to the host system
 func prepInjectHostIP(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Cluster, clusterStartOpts *k3d.ClusterStartOpts) error {
 	if cluster.Network.Name == "host" {
-		l.Log().Tracef("Not injecting hostIP as clusternetwork is 'host'")
+		l.Log().Debugf("Not injecting host.k3d.internal into /etc/hosts as clusternetwork is 'host'")
 		return nil
 	}
 

--- a/pkg/client/environment.go
+++ b/pkg/client/environment.go
@@ -50,12 +50,14 @@ func GatherEnvironmentInfo(ctx context.Context, runtime runtimes.Runtime, cluste
 		go NodeDelete(ctx, runtime, toolsNode, k3d.NodeDeleteOpts{SkipLBUpdate: true})
 	}()
 
-	hostIP, err := GetHostIP(ctx, runtime, cluster)
-	if err != nil {
-		return envInfo, fmt.Errorf("failed to get host IP: %w", err)
-	}
+	if cluster.Network.Name != "host" {
+		hostIP, err := GetHostIP(ctx, runtime, cluster)
+		if err != nil {
+			return envInfo, fmt.Errorf("failed to get host IP: %w", err)
+		}
 
-	envInfo.HostGateway = hostIP
+		envInfo.HostGateway = hostIP
+	}
 
 	return envInfo, nil
 

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -224,21 +224,23 @@ func NodeAddToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 		)
 	}
 
-	// add host.k3d.internal to /etc/hosts
-	createNodeOpts.NodeHooks = append(createNodeOpts.NodeHooks,
-		k3d.NodeHook{
-			Stage: k3d.LifecycleStagePostStart,
-			Action: actions.ExecAction{
-				Runtime: runtime,
-				Command: []string{
-					"sh", "-c",
-					fmt.Sprintf("echo '%s %s' >> /etc/hosts", envInfo.HostGateway.String(), k3d.DefaultK3dInternalHostRecord),
+	if cluster.Network.Name != "host" {
+		// add host.k3d.internal to /etc/hosts
+		createNodeOpts.NodeHooks = append(createNodeOpts.NodeHooks,
+			k3d.NodeHook{
+				Stage: k3d.LifecycleStagePostStart,
+				Action: actions.ExecAction{
+					Runtime: runtime,
+					Command: []string{
+						"sh", "-c",
+						fmt.Sprintf("echo '%s %s' >> /etc/hosts", envInfo.HostGateway.String(), k3d.DefaultK3dInternalHostRecord),
+					},
+					Retries:     0,
+					Description: fmt.Sprintf("Inject /etc/hosts record for %s", k3d.DefaultK3dInternalHostRecord),
 				},
-				Retries:     0,
-				Description: fmt.Sprintf("Inject /etc/hosts record for %s", k3d.DefaultK3dInternalHostRecord),
 			},
-		},
-	)
+		)
+	}
 
 	// clear status fields
 	node.State.Running = false

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -101,7 +101,7 @@ func removeContainer(ctx context.Context, ID string) error {
 		return fmt.Errorf("docker failed to remove the container '%s': %w", ID, err)
 	}
 
-	l.Log().Infoln("Deleted", ID)
+	l.Log().Tracef("[Docker] Deleted Container %s", ID)
 
 	return nil
 }

--- a/pkg/runtimes/docker/translate.go
+++ b/pkg/runtimes/docker/translate.go
@@ -285,7 +285,7 @@ func TranslateContainerDetailsToNode(containerDetails types.ContainerJSON) (*k3d
 	} else {
 		l.Log().Debugf("no netlabel present on container %s", containerDetails.Name)
 	}
-	if clusterNet != nil {
+	if clusterNet != nil && labels[k3d.LabelNetwork] != "host" {
 		parsedIP, err := netaddr.ParseIP(clusterNet.IPAddress)
 		if err != nil {
 			if nodeState.Running && nodeState.Status != "restarting" { // if the container is not running or currently restarting, it won't have an IP, so we don't error in that case


### PR DESCRIPTION
## Changes

- do not try to get host gateway IP via tools node or network inspect
- do not try to inject host.k3d.internal into /etc/hosts
- do not try to inject host.k3d.internal into CoreDNS configmap
- when getting node info from container, do not try to get IP info

## Linked PRs/Issues

- fixes #842