### PR TITLE
[Enhancement] extend usability of nodefilters with suffices internally...

### DIFF
--- a/pkg/client/ports.go
+++ b/pkg/client/ports.go
@@ -61,12 +61,16 @@ func TransformPorts(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.
 			}
 		}
 
-		filteredNodes, err := util.FilterNodesWithSuffix(nodeList, portWithNodeFilters.NodeFilters)
+		filteredNodes, err := util.FilterNodesWithSuffix(nodeList, portWithNodeFilters.NodeFilters, "proxy", "direct") // TODO: move "proxy" and "direct" allowed suffices to constants
 		if err != nil {
 			return err
 		}
 
 		for suffix, nodes := range filteredNodes {
+			// skip, if no nodes in filtered set, so we don't add portmappings with no targets in the backend
+			if len(nodes) == 0 {
+				continue
+			}
 			portmappings, err := nat.ParsePortSpec(portWithNodeFilters.Port)
 			if err != nil {
 				return fmt.Errorf("error parsing port spec '%s': %+v", portWithNodeFilters.Port, err)

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -44,10 +44,6 @@ import (
 	l "github.com/rancher/k3d/v5/pkg/logger"
 )
 
-var (
-	DefaultTargetsNodefiltersPortMappings = []string{"servers:*:proxy", "agents:*:proxy"}
-)
-
 // TransformSimpleToClusterConfig transforms a simple configuration to a full-fledged cluster configuration
 func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtime, simpleConfig conf.SimpleConfig) (*conf.ClusterConfig, error) {
 


### PR DESCRIPTION
... and throw error if suffix is used in unsupported cases (e.g. volumes)

Note: as of now, only the port config supports nodefilter suffices (proxy, direct) and all the others don't.

fixes 852
