### PR TITLE
[FIX] getHostIP: fix failing on DfD and init new host.k3d.internal injection

### DIFF
--- a/pkg/client/host.go
+++ b/pkg/client/host.go
@@ -28,10 +28,10 @@ import (
 	"net"
 	"regexp"
 	goruntime "runtime"
-	"strings"
 
 	l "github.com/rancher/k3d/v5/pkg/logger"
 	"github.com/rancher/k3d/v5/pkg/runtimes"
+	"github.com/rancher/k3d/v5/pkg/runtimes/docker"
 	k3d "github.com/rancher/k3d/v5/pkg/types"
 	"github.com/rancher/k3d/v5/pkg/util"
 )
@@ -64,15 +64,11 @@ func GetHostIP(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Clust
 
 	l.Log().Tracef("GOOS: %s / Runtime OS: %s (%s)", goruntime.GOOS, rtimeInfo.OSType, rtimeInfo.OS)
 
-	isDockerDesktop := func(os string) bool {
-		return strings.ToLower(os) == "docker desktop"
-	}
-
 	// Docker Runtime
 	if runtime == runtimes.Docker {
 
 		// Docker (for Desktop) on MacOS or Windows
-		if isDockerDesktop(rtimeInfo.OS) {
+		if docker.IsDockerDesktop(rtimeInfo.OS) {
 
 			toolsNode, err := EnsureToolsNode(ctx, runtime, cluster)
 			if err != nil {

--- a/pkg/client/host.go
+++ b/pkg/client/host.go
@@ -79,9 +79,16 @@ func GetHostIP(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Clust
 				return nil, fmt.Errorf("failed to ensure that k3d-tools node is running to get host IP :%w", err)
 			}
 
-			ip, err := resolveHostnameFromInside(ctx, runtime, toolsNode, "host.docker.internal", ResolveHostCmdGetEnt)
+			k3dInternalIP, err := resolveHostnameFromInside(ctx, runtime, toolsNode, k3d.DefaultK3dInternalHostRecord, ResolveHostCmdGetEnt)
 			if err == nil {
-				return ip, nil
+				return k3dInternalIP, nil
+			}
+
+			l.Log().Debugf("[GetHostIP on Docker Desktop] failed to resolve '%s' from inside the k3d-tools node: %v", k3d.DefaultK3dInternalHostRecord, err)
+
+			dockerInternalIP, err := resolveHostnameFromInside(ctx, runtime, toolsNode, "host.docker.internal", ResolveHostCmdGetEnt)
+			if err == nil {
+				return dockerInternalIP, nil
 			}
 
 			l.Log().Debugf("[GetHostIP on Docker Desktop] failed to resolve 'host.docker.internal' from inside the k3d-tools node: %v", err)

--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -25,13 +25,14 @@ package client
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	l "github.com/rancher/k3d/v5/pkg/logger"
 	"github.com/rancher/k3d/v5/pkg/runtimes"
@@ -385,6 +386,7 @@ func runToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cl
 		Cmd:           []string{},
 		Args:          []string{"noop"},
 		RuntimeLabels: labels,
+		ExtraHosts:    []string{fmt.Sprintf("%s:host-gateway", k3d.DefaultK3dInternalHostRecord)},
 	}
 	node.RuntimeLabels[k3d.LabelClusterName] = cluster.Name
 	if err := NodeRun(ctx, runtime, node, k3d.NodeCreateOpts{}); err != nil {

--- a/pkg/runtimes/docker/docker.go
+++ b/pkg/runtimes/docker/docker.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package docker
 
 import (
+	"net"
 	"net/url"
 	"os"
 
@@ -42,13 +43,43 @@ func (d Docker) ID() string {
 
 // GetHost returns the docker daemon host
 func (d Docker) GetHost() string {
+	// a) DOCKER_HOST env var
 	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost == "" {
+		l.Log().Traceln("[Docker] GetHost: DOCKER_HOST empty/unset")
+		info, err := d.Info()
+		if err != nil {
+			l.Log().Errorf("error getting runtime information: %v", err)
+			return ""
+		}
+		// b) Docker for Desktop (Win/Mac) and it's a local connection
+		if IsDockerDesktop(info.OS) && IsLocalConnection(info.Endpoint) {
+			// b.1) local DfD connection, but inside WSL, where host.docker.internal resolves to an IP, but it's not reachable
+			if _, ok := os.LookupEnv("WSL_DISTRO_NAME"); ok {
+				l.Log().Debugln("wanted to use 'host.docker.internal' as docker host, but it's not reachable in WSL2")
+				return ""
+			}
+			l.Log().Debugln("[Docker] Local DfD: using 'host.docker.internal'")
+			dockerHost = "host.docker.internal"
+			if _, err := net.LookupHost(dockerHost); err != nil {
+				l.Log().Debugf("wanted to use 'host.docker.internal' as docker host, but it's not resolvable locally: %v", err)
+				return ""
+			}
+		}
+	}
 	url, err := url.Parse(dockerHost)
 	if err != nil {
+		l.Log().Debugf("[Docker] GetHost: error parsing '%s' as URL: %#v", dockerHost, url)
 		return ""
 	}
-	l.Log().Debugf("DockerHost: %s", url.Host)
-	return url.Host
+	dockerHost = url.Host
+	// apparently, host.docker.internal is not parsed as host but
+	if dockerHost == "" && url.String() != "" {
+		dockerHost = url.String()
+	}
+	l.Log().Debugf("DockerHost: '%s' (%+v)", dockerHost, url)
+
+	return dockerHost
 }
 
 // GetRuntimePath returns the path of the docker socket

--- a/pkg/runtimes/docker/util.go
+++ b/pkg/runtimes/docker/util.go
@@ -28,6 +28,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
@@ -41,6 +43,22 @@ import (
 	k3d "github.com/rancher/k3d/v5/pkg/types"
 	"github.com/spf13/pflag"
 )
+
+func IsDockerDesktop(os string) bool {
+	return strings.ToLower(os) == "docker desktop"
+}
+
+/*
+ * Simple Matching to detect local connection:
+ * - file (socket): starts with / (absolute path)
+ * - tcp://(localhost|127.0.0.1)
+ * - ssh://(localhost|127.0.0.1)
+ */
+var LocalConnectionRegexp = regexp.MustCompile(`^(/|((tcp|ssh)://(localhost|127\.0\.0\.1))).*`)
+
+func IsLocalConnection(endpoint string) bool {
+	return LocalConnectionRegexp.Match([]byte(endpoint))
+}
 
 // GetDefaultObjectLabelsFilter returns docker type filters created from k3d labels
 func GetDefaultObjectLabelsFilter(clusterName string) filters.Args {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -200,7 +200,7 @@ var ImportModes = map[string]ImportMode{
 type ImageImportOpts struct {
 	KeepTar       bool
 	KeepToolsNode bool
-	Mode   ImportMode
+	Mode          ImportMode
 }
 
 type IPAM struct {


### PR DESCRIPTION
## Changes

- do not close connection of exec process before having read everything
  - as a backwards-compatible fix, we now read all logs into a new
  bufio.Reader so we can savely close the connection and original reader
- start tools node with --add-host=host.k3d.internal:host-gateway
(docker feature) and use it for getHostIP on DfD (TODO: we can use this
on all platforms)

## To-Do

- [x] if DfD && local (i.e. no non-local tcp/ssh connection) && host.docker.internal resolvable locally; then host.docker.internal in kubeconfig
	- Problem: e.g. in WSL2, all of the above conditions are true, but `host.docker.internal` is not reachable
		- Pinging it with a library would draw in unnecessary dependencies
		- As an alternative check, we just look if the `WSL_DISTRO_NAME` env var is present to determine if k3d is running in WSL2 and if so, we do not use host.docker.internal

## Links

- fixes #858 (both problems)