### PR TITLE
[Fix] only replace default api host with docker host

### DIFF
--- a/cmd/registry/registryCreate.go
+++ b/cmd/registry/registryCreate.go
@@ -41,9 +41,9 @@ type regCreatePreProcessedFlags struct {
 }
 
 type regCreateFlags struct {
-	Image          string
+	Image   string
 	Network string
-	NoHelp         bool
+	NoHelp  bool
 }
 
 var helptext string = `# You can now use the registry like this (example):

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -673,17 +673,6 @@ func patchServerSpec(node *k3d.Node, runtime runtimes.Runtime) error {
 	node.RuntimeLabels[k3d.LabelServerAPIHost] = node.ServerOpts.KubeAPI.Host
 	node.RuntimeLabels[k3d.LabelServerAPIPort] = node.ServerOpts.KubeAPI.Binding.HostPort
 
-	// If the runtime is docker, attempt to use the docker host
-	if runtime == runtimes.Docker {
-		dockerHost := runtime.GetHost()
-		if dockerHost != "" {
-			dockerHost = strings.Split(dockerHost, ":")[0] // remove the port
-			l.Log().Tracef("Using docker host %s", dockerHost)
-			node.RuntimeLabels[k3d.LabelServerAPIHostIP] = dockerHost
-			node.RuntimeLabels[k3d.LabelServerAPIHost] = dockerHost
-		}
-	}
-
 	node.Args = append(node.Args, "--tls-san", node.RuntimeLabels[k3d.LabelServerAPIHost]) // add TLS SAN for non default host name
 
 	return nil


### PR DESCRIPTION
fixes #876 

## Changes

- move docker-machine lookup into general GetHost function
- only use GetHost result if API host is default (0.0.0.0) to not override user-provided value
- when looking up IP for host value (e.g. localhost), only use IPv4 to prevent errors