### PR TITLE
[Fix] Removing non-existing cluster via configuration

### DIFF
--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -131,8 +132,9 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 		}
 
 		c, err := client.ClusterGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: clusterDeleteCfgViper.GetString("name")})
-		if err != nil {
-			l.Log().Fatalf("failed to delete cluster '%s': %v", clusterDeleteCfgViper.GetString("name"), err)
+		if errors.Is(err, client.ClusterGetNoNodesFoundError) {
+			l.Log().Infof("No nodes found for cluster '%s', nothing to delete.", clusterDeleteCfgViper.GetString("name"))
+			return nil
 		}
 
 		clusters = append(clusters, c)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What
With k3d I can delete a cluster before it is created. Such a use case is very useful in case I want to restart my test environment. 
```Makefile
reset:
     k3d cluster delete mycluster
     k3d cluster create mycluster
     <installing things....>
```
Even better is to use a configuration with the argument `-c config.yaml`. The k3d can delete a 
cluster based on configuration, but it cannot handle the case that the cluster does not exist.

```log
INFO[0000] Using config file ./local.yaml (k3d.io/v1alpha3#simple) 
FATA[0000] failed to delete cluster 'mycluster': No nodes found for given cluster 
```

This PR allows that if I use the configuration and delete a non-existing cluster, k3d will not end up fatal.
```log
# k3d cluster delete -c ./local.yaml
INFO[0000] Using config file ./local.yaml (k3d.io/v1alpha3#simple) 
INFO[0000] No nodes found for cluster 'mucluster', nothing to delete. 
INFO[0000] No clusters found                            
```

# Why
It is important for me that the cluster name is used in one single place - ideally the configuration.
Thanks to this PR I can do the following:
```Makefile
reset:
	k3d cluster delete -c cluster/local.yaml
	k3d cluster create -c cluster/local.yaml
```


<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
The change concerns one scenario - deleting a non-existing cluster if the cluster name is in the configuration. 

Signed-off-by: kuritka <kuritka@gmail.com>