### PR TITLE
add: schema versions in-repo to link to from schemastore.org

### DIFF
--- a/pkg/config/config.versions.meta.schema.json
+++ b/pkg/config/config.versions.meta.schema.json
@@ -1,0 +1,74 @@
+{
+  "$id": "https://github.com/rancher/k3d/tree/main/pkg/config/config.versions.meta.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "The meta schema for k3d's config version schemas.",
+  "type": "object",
+  "allOf": [
+  {
+    "$ref": "http://json-schema.org/draft-07/schema#"
+  },
+  {
+    "properties": {
+    "oneOf": {
+      "type": "array",
+      "items": {
+      "type": "object",
+      "required": ["allOf"],
+      "additionalProperties": false,
+      "properties": {
+        "allOf": {
+        "type": "array",
+        "additionalItems": false,
+        "minItems": 2,
+        "items": [
+          {
+          "type": "object",
+          "required": [
+            "properties"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "properties": {
+            "type": "object",
+            "required": [
+              "version"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "version": {
+              "type": "object",
+              "required": [
+                "const"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "const": {
+                "type": "string"
+                }
+              }
+              }
+            }
+            }
+          }
+          },
+          {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "$ref": {
+            "type": "string"
+            }
+          }
+          }
+        ]
+        }
+      }
+      }
+    }
+    }
+  }
+  ]
+}

--- a/pkg/config/config.versions.schema.json
+++ b/pkg/config/config.versions.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://github.com/rancher/k3d/tree/main/pkg/config/config.versions.schema.json",
+  "$schema": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/config.versions.meta.schema.json#",
+  "title": "All k3d config versions",
+  "type": "object",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v1alpha3"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha3/schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v1alpha2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha2/schema.json"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/config/v1alpha2/schema.json
+++ b/pkg/config/v1alpha2/schema.json
@@ -23,8 +23,8 @@
     },
     "name": {
       "description": "Name of the cluster (must be a valid hostname and will be prefixed with 'k3d-'). Example: 'mycluster'.",
-			"type": "string",
-			"format": "hostname"
+      "type": "string",
+      "format": "hostname"
     },
     "servers": {
       "type": "number",
@@ -50,7 +50,7 @@
           ]
         },
         "hostPort": {
-          "type":"string",
+          "type": "string",
           "examples": [
             "6443"
           ]
@@ -86,7 +86,7 @@
           "volume": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -101,7 +101,7 @@
           "port": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -116,7 +116,7 @@
           "label": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -217,7 +217,7 @@
           "envVar": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -230,7 +230,7 @@
   },
   "additionalProperties": false,
   "definitions": {
-    "nodeFilters": {  
+    "nodeFilters": {
       "type": "array",
       "items": {
         "type": "string"

--- a/pkg/config/v1alpha3/schema.json
+++ b/pkg/config/v1alpha3/schema.json
@@ -23,8 +23,8 @@
     },
     "name": {
       "description": "Name of the cluster (must be a valid hostname and will be prefixed with 'k3d-'). Example: 'mycluster'.",
-			"type": "string",
-			"format": "hostname"
+      "type": "string",
+      "format": "hostname"
     },
     "servers": {
       "type": "number",
@@ -50,7 +50,7 @@
           ]
         },
         "hostPort": {
-          "type":"string",
+          "type": "string",
           "examples": [
             "6443"
           ]
@@ -86,7 +86,7 @@
           "volume": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -101,7 +101,7 @@
           "port": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -141,7 +141,7 @@
               "type": "object",
               "properties": {
                 "configOverrides": {
-                  "type":"array",
+                  "type": "array",
                   "examples": [
                     "settings.workerConnections=2048",
                     "settings.defaultProxyTimeout=900"
@@ -163,7 +163,10 @@
                 "properties": {
                   "arg": {
                     "type": "string",
-                    "examples": ["--tls-san=127.0.0.1", "--disable=traefik"]
+                    "examples": [
+                      "--tls-san=127.0.0.1",
+                      "--disable=traefik"
+                    ]
                   },
                   "nodeFilters": {
                     "$ref": "#/definitions/nodeFilters"
@@ -244,7 +247,7 @@
           "envVar": {
             "type": "string"
           },
-          "nodeFilters": {  
+          "nodeFilters": {
             "$ref": "#/definitions/nodeFilters"
           }
         },
@@ -323,7 +326,7 @@
   },
   "additionalProperties": false,
   "definitions": {
-    "nodeFilters": {  
+    "nodeFilters": {
       "type": "array",
       "items": {
         "type": "string"


### PR DESCRIPTION
- embed a versions file in the k3d repo that links to the existing config schemas as per https://github.com/SchemaStore/schemastore/pull/2057#issuecomment-1024470105
- inspired by and mostly copied from https://github.com/ory/kratos/blob/master/.schema/version.schema.json :pray: 