### PR TITLE
[FEATURE] Config file compatible with Kustomize

### DIFF
--- a/docs/usage/configfile.md
+++ b/docs/usage/configfile.md
@@ -52,7 +52,8 @@ Since the config options and the config file are changing quite a bit, it's hard
 # k3d configuration file, saved as e.g. /home/me/myk3dcluster.yaml
 apiVersion: k3d.io/v1alpha4 # this will change in the future as we make everything more stable
 kind: Simple # internally, we also have a Cluster config, which is not yet available externally
-name: mycluster # name that you want to give to your cluster (will still be prefixed with `k3d-`)
+metadata:
+  name: mycluster # name that you want to give to your cluster (will still be prefixed with `k3d-`)
 servers: 1 # same as `--servers 1`
 agents: 2 # same as `--agents 2`
 kubeAPI: # same as `--api-port myhost.my.domain:6445` (where the name would resolve to 127.0.0.1)

--- a/docs/usage/registries.md
+++ b/docs/usage/registries.md
@@ -25,7 +25,8 @@ If you're using a `SimpleConfig` file to configure your k3d cluster, you may as 
 ```yaml
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test
+metadata:
+  name: test
 servers: 1
 agents: 2
 registries:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,7 +44,9 @@ func TestReadSimpleConfig(t *testing.T) {
 			APIVersion: "k3d.io/v1alpha4",
 			Kind:       "Simple",
 		},
-		Name:      "test",
+		ObjectMeta: configtypes.ObjectMeta{
+			Name: "test",
+		},
 		Servers:   1,
 		Agents:    2,
 		ExposeAPI: exposedAPI,
@@ -268,7 +270,9 @@ func TestReadSimpleConfigRegistries(t *testing.T) {
 			APIVersion: "k3d.io/v1alpha4",
 			Kind:       "Simple",
 		},
-		Name:    "test",
+		ObjectMeta: configtypes.ObjectMeta{
+			Name: "test",
+		},
 		Servers: 1,
 		Agents:  1,
 		Registries: conf.SimpleConfigRegistries{

--- a/pkg/config/jsonschema_test.go
+++ b/pkg/config/jsonschema_test.go
@@ -46,7 +46,7 @@ func TestValidateSchemaFail(t *testing.T) {
 		t.Errorf("Validation of config file %s against the default schema passed where we expected a failure", cfgPath)
 	}
 
-	expectedErrorText := `- name: Invalid type. Expected: string, given: integer
+	expectedErrorText := `- metadata.name: Invalid type. Expected: string, given: integer
 `
 
 	if err.Error() != expectedErrorText {

--- a/pkg/config/test_assets/config_test_registries.yaml
+++ b/pkg/config/test_assets/config_test_registries.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test
+metadata:
+  name: test
 servers: 1
 agents: 1
 registries:

--- a/pkg/config/test_assets/config_test_simple.yaml
+++ b/pkg/config/test_assets/config_test_simple.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test
+metadata:
+  name: test
 servers: 1
 agents: 2
 kubeAPI:

--- a/pkg/config/test_assets/config_test_simple_2.yaml
+++ b/pkg/config/test_assets/config_test_simple_2.yaml
@@ -1,4 +1,5 @@
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: supertest
+metadata:
+  name: supertest
 agents: 8

--- a/pkg/config/test_assets/config_test_simple_invalid_servers.yaml
+++ b/pkg/config/test_assets/config_test_simple_invalid_servers.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: 1234
+metadata:
+  name: 1234
 servers: 1
 agents: 2
 kubeAPI:

--- a/pkg/config/test_assets/config_test_simple_migration_v1alpha4.yaml
+++ b/pkg/config/test_assets/config_test_simple_migration_v1alpha4.yaml
@@ -4,24 +4,36 @@ metadata:
   name: test
 servers: 3
 agents: 2
+kubeAPI:
+  hostIP: "0.0.0.0"
+  hostPort: "6446"
 #image: rancher/k3s:latest
 volumes:
-  - volume: $HOME:/some/path
+  - volume: /my/path:/some/path
     nodeFilters:
       - all
+ports:
+  - port: 80:80
+    nodeFilters:
+      - loadbalancer
+  - port: 0.0.0.0:443:443
+    nodeFilters:
+      - loadbalancer
 env:
   - envVar: bar=baz,bob
     nodeFilters:
       - all
 registries:
   create:
-    name: registry.localhost
-  use: []
+    name: k3d-test-registry
+    host: "0.0.0.0"
+    hostPort: random
   config: |
     mirrors:
       "my.company.registry":
         endpoint:
           - http://my.company.registry:5000
+
 options:
   k3d:
     wait: true
@@ -33,11 +45,6 @@ options:
       - arg: --tls-san=127.0.0.1
         nodeFilters:
           - server:*
-    nodeLabels:
-      - label: foo=bar
-        nodeFilters:
-          - server:0
-          - loadbalancer
   kubeconfig:
     updateDefaultKubeconfig: true
     switchCurrentContext: true

--- a/pkg/config/types/types.go
+++ b/pkg/config/types/types.go
@@ -27,6 +27,11 @@ type TypeMeta struct {
 	APIVersion string `mapstructure:"apiVersion,omitempty" yaml:"apiVersion,omitempty" json:"apiVersion,omitempty"`
 }
 
+// ObjectMeta got its name from the Kubernetes counterpart.
+type ObjectMeta struct {
+	Name string `mapstructure:"name,omitempty" yaml:"name,omitempty" json:"name,omitempty"`
+}
+
 // Config interface.
 type Config interface {
 	GetKind() string

--- a/pkg/config/v1alpha4/schema.json
+++ b/pkg/config/v1alpha4/schema.json
@@ -21,10 +21,16 @@
       ],
       "default": "Simple"
     },
-    "name": {
-      "description": "Name of the cluster (must be a valid hostname and will be prefixed with 'k3d-'). Example: 'mycluster'.",
-      "type": "string",
-      "format": "hostname"
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the cluster (must be a valid hostname and will be prefixed with 'k3d-'). Example: 'mycluster'.",
+          "type": "string",
+          "format": "hostname"
+        }
+      },
+      "additionalProperties": false
     },
     "servers": {
       "type": "number",
@@ -220,7 +226,7 @@
               "type": "string"
             },
             "hostPidMode": {
-              "type":"boolean",
+              "type": "boolean",
               "default": false
             },
             "labels": {

--- a/pkg/config/v1alpha4/types.go
+++ b/pkg/config/v1alpha4/types.go
@@ -135,21 +135,21 @@ type SimpleConfigRegistries struct {
 
 // SimpleConfig describes the toplevel k3d configuration file.
 type SimpleConfig struct {
-	config.TypeMeta `mapstructure:",squash" yaml:",inline"`
-	Name            string                  `mapstructure:"name" yaml:"name,omitempty" json:"name,omitempty"`
-	Servers         int                     `mapstructure:"servers" yaml:"servers,omitempty" json:"servers,omitempty"` //nolint:lll    // default 1
-	Agents          int                     `mapstructure:"agents" yaml:"agents,omitempty" json:"agents,omitempty"`    //nolint:lll    // default 0
-	ExposeAPI       SimpleExposureOpts      `mapstructure:"kubeAPI" yaml:"kubeAPI,omitempty" json:"kubeAPI,omitempty"`
-	Image           string                  `mapstructure:"image" yaml:"image,omitempty" json:"image,omitempty"`
-	Network         string                  `mapstructure:"network" yaml:"network,omitempty" json:"network,omitempty"`
-	Subnet          string                  `mapstructure:"subnet" yaml:"subnet,omitempty" json:"subnet,omitempty"`
-	ClusterToken    string                  `mapstructure:"token" yaml:"clusterToken,omitempty" json:"clusterToken,omitempty"` // default: auto-generated
-	Volumes         []VolumeWithNodeFilters `mapstructure:"volumes" yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	Ports           []PortWithNodeFilters   `mapstructure:"ports" yaml:"ports,omitempty" json:"ports,omitempty"`
-	Options         SimpleConfigOptions     `mapstructure:"options" yaml:"options,omitempty" json:"options,omitempty"`
-	Env             []EnvVarWithNodeFilters `mapstructure:"env" yaml:"env,omitempty" json:"env,omitempty"`
-	Registries      SimpleConfigRegistries  `mapstructure:"registries" yaml:"registries,omitempty" json:"registries,omitempty"`
-	HostAliases     []k3d.HostAlias         `mapstructure:"hostAliases" yaml:"hostAliases,omitempty" json:"hostAliases,omitempty"`
+	config.TypeMeta   `mapstructure:",squash" yaml:",inline"`
+	config.ObjectMeta `mapstructure:"metadata" yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	Servers           int                     `mapstructure:"servers" yaml:"servers,omitempty" json:"servers,omitempty"` //nolint:lll    // default 1
+	Agents            int                     `mapstructure:"agents" yaml:"agents,omitempty" json:"agents,omitempty"`    //nolint:lll    // default 0
+	ExposeAPI         SimpleExposureOpts      `mapstructure:"kubeAPI" yaml:"kubeAPI,omitempty" json:"kubeAPI,omitempty"`
+	Image             string                  `mapstructure:"image" yaml:"image,omitempty" json:"image,omitempty"`
+	Network           string                  `mapstructure:"network" yaml:"network,omitempty" json:"network,omitempty"`
+	Subnet            string                  `mapstructure:"subnet" yaml:"subnet,omitempty" json:"subnet,omitempty"`
+	ClusterToken      string                  `mapstructure:"token" yaml:"clusterToken,omitempty" json:"clusterToken,omitempty"` // default: auto-generated
+	Volumes           []VolumeWithNodeFilters `mapstructure:"volumes" yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Ports             []PortWithNodeFilters   `mapstructure:"ports" yaml:"ports,omitempty" json:"ports,omitempty"`
+	Options           SimpleConfigOptions     `mapstructure:"options" yaml:"options,omitempty" json:"options,omitempty"`
+	Env               []EnvVarWithNodeFilters `mapstructure:"env" yaml:"env,omitempty" json:"env,omitempty"`
+	Registries        SimpleConfigRegistries  `mapstructure:"registries" yaml:"registries,omitempty" json:"registries,omitempty"`
+	HostAliases       []k3d.HostAlias         `mapstructure:"hostAliases" yaml:"hostAliases,omitempty" json:"hostAliases,omitempty"`
 }
 
 // SimpleExposureOpts provides a simplified syntax compared to the original k3d.ExposureOpts

--- a/tests/assets/config_env.yaml
+++ b/tests/assets/config_env.yaml
@@ -1,4 +1,5 @@
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: testenvexpand
+metadata:
+  name: testenvexpand
 servers: ${K3D_TEST_SERVERS}


### PR DESCRIPTION
# What

Move `name` to `metadata.name` in `k3d.io/v1alpha4 Simple` config file format.

# Why

Fixes #937 

This change in config format allow users to kustomize cluster-config using `kustomize`.

# Implications

This is a breaking change in the `v1alpha4` config-format, but this is a new and currently unreleased version.