### PR TITLE
fix: serverlb should be created before using and restarted unless stopped

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -510,11 +510,13 @@ ClusterCreatOpts:
 	if !clusterCreateOpts.DisableLoadBalancer {
 		if cluster.ServerLoadBalancer == nil {
 			l.Log().Infof("No loadbalancer specified, creating a default one...")
-			lbNode, err := LoadbalancerPrepare(ctx, runtime, cluster, &k3d.LoadbalancerCreateOpts{Labels: clusterCreateOpts.GlobalLabels})
+			cluster.ServerLoadBalancer = k3d.NewLoadbalancer()
+			var err error
+			cluster.ServerLoadBalancer.Node, err = LoadbalancerPrepare(ctx, runtime, cluster, &k3d.LoadbalancerCreateOpts{Labels: clusterCreateOpts.GlobalLabels})
 			if err != nil {
 				return fmt.Errorf("failed to prepare loadbalancer: %w", err)
 			}
-			cluster.Nodes = append(cluster.Nodes, lbNode) // append lbNode to list of cluster nodes, so it will be considered during rollback
+			cluster.Nodes = append(cluster.Nodes, cluster.ServerLoadBalancer.Node) // append lbNode to list of cluster nodes, so it will be considered during rollback
 		}
 
 		if len(cluster.ServerLoadBalancer.Config.Ports) == 0 {

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -545,7 +545,6 @@ ClusterCreatOpts:
 		}
 
 		cluster.ServerLoadBalancer.Node.HookActions = append(cluster.ServerLoadBalancer.Node.HookActions, writeLbConfigAction)
-		cluster.ServerLoadBalancer.Node.RuntimeLabels = clusterCreateOpts.GlobalLabels
 		cluster.ServerLoadBalancer.Node.Restart = true
 
 		l.Log().Infof("Creating LoadBalancer '%s'", cluster.ServerLoadBalancer.Node.Name)

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -525,8 +525,6 @@ ClusterCreatOpts:
 			cluster.ServerLoadBalancer.Config = &lbConfig
 		}
 
-		cluster.ServerLoadBalancer.Node.RuntimeLabels = clusterCreateOpts.GlobalLabels
-
 		// prepare to write config to lb container
 		configyaml, err := yaml.Marshal(cluster.ServerLoadBalancer.Config)
 		if err != nil {
@@ -545,6 +543,8 @@ ClusterCreatOpts:
 		}
 
 		cluster.ServerLoadBalancer.Node.HookActions = append(cluster.ServerLoadBalancer.Node.HookActions, writeLbConfigAction)
+		cluster.ServerLoadBalancer.Node.RuntimeLabels = clusterCreateOpts.GlobalLabels
+		cluster.ServerLoadBalancer.Node.Restart = true
 
 		l.Log().Infof("Creating LoadBalancer '%s'", cluster.ServerLoadBalancer.Node.Name)
 		if err := NodeCreate(ctx, runtime, cluster.ServerLoadBalancer.Node, k3d.NodeCreateOpts{}); err != nil {


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What

fix 2 problems
1. serverlb should restart unless stopped
2. serverLoadBalancer should be created before using in avoid of panic

# Why

issue https://github.com/rancher/k3d/issues/947

# Implications

fix corner case

