### PR TITLE
Fix typo in node.go

### DIFF
--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -429,7 +429,7 @@ func NodeStart(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, no
 	if node.State.Started != "" {
 		ts, err := time.Parse("2006-01-02T15:04:05.999999999Z", node.State.Started)
 		if err != nil {
-			l.Log().Debugf("Failed to parse '%s.State.Started' timestamp '%s', falling back to calulated time", node.Name, node.State.Started)
+			l.Log().Debugf("Failed to parse '%s.State.Started' timestamp '%s', falling back to calculated time", node.Name, node.State.Started)
 		}
 		startTime = ts.Truncate(time.Second)
 		l.Log().Debugf("Truncated %s to %s", ts, startTime)


### PR DESCRIPTION


<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What

Fixed typo.
```
calulated -> calculated
```

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
