### PR TITLE
fix: invert logic for LOG_LEVEL parsing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,7 +156,7 @@ func initLogging() {
 	} else {
 		if ll := os.Getenv("LOG_LEVEL"); ll != "" {
 			level, err := logrus.ParseLevel(ll)
-			if err != nil {
+			if err == nil {
 				l.Log().SetLevel(level)
 			}
 		}


### PR DESCRIPTION
Currently the log level is only set if an error occurs during the
parsing of the LOG_LEVEL environment variable. This logic needs to be
inverted, and the log level set if there is no error.
